### PR TITLE
[#167707754, #167604609] Handle score and goal adjustments and gaps

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -29,12 +29,9 @@ class GoalsController < ApplicationController
 
   def create
     crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
-    benchmarks_and_activities =
-      JSON.load File.open './app/fixtures/benchmarks_and_activities.json'
+    benchmarks = BenchmarksFixture.new
 
     goal_params = params.fetch(:goal_form)
-    redirect_to GoalForm.create_draft_plan! goal_params,
-                                            crosswalk,
-                                            benchmarks_and_activities
+    redirect_to GoalForm.create_draft_plan! goal_params, crosswalk, benchmarks
   end
 end

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -1,0 +1,35 @@
+class InvalidParameter < Exception; end
+class OutOfBounds < Exception; end
+
+class BenchmarksFixture
+  def initialize
+    @fixture =
+      JSON.load File.open './app/fixtures/benchmarks_and_activities.json'
+  end
+
+  def activities(benchmark_id, args)
+    raise "Unknown benchmark: #{benchmark_id}" unless @fixture[benchmark_id]
+
+    if args[:score] && args[:goal]
+      if args[:goal] && ((args[:goal] < 2) || (5 < args[:goal]))
+        raise OutOfBounds.new args[:goal]
+      end
+      if args[:score] && ((args[:score] < 2) || (5 < args[:score]))
+        raise OutOfBounds.new args[:score]
+      end
+      raise InvalidParameter unless args[:score] <= args[:goal]
+
+      return (args[:score] + 1..args[:goal]).reduce([]) do |acc, level|
+        acc.concat @fixture[benchmark_id]['capacity'][level.to_s]
+        acc
+      end
+    elsif args[:level]
+      if args[:level] && ((args[:level] < 2) || (5 < args[:level]))
+        raise OutOfBounds.new args[:level]
+      end
+      return @fixture[benchmark_id]['capacity'][args[:level].to_s]
+    end
+
+    raise InvalidParameter
+  end
+end

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -14,7 +14,7 @@ class BenchmarksFixture
       if args[:goal] && ((args[:goal] < 2) || (5 < args[:goal]))
         raise OutOfBounds.new args[:goal]
       end
-      if args[:score] && ((args[:score] < 2) || (5 < args[:score]))
+      if args[:score] && ((args[:score] < 1) || (5 < args[:score]))
         raise OutOfBounds.new args[:score]
       end
       raise InvalidParameter unless args[:score] <= args[:goal]

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -1,35 +1,30 @@
-class InvalidParameter < Exception; end
-class OutOfBounds < Exception; end
-
 class BenchmarksFixture
   def initialize
     @fixture =
       JSON.load File.open './app/fixtures/benchmarks_and_activities.json'
   end
 
-  def activities(benchmark_id, args)
-    raise "Unknown benchmark: #{benchmark_id}" unless @fixture[benchmark_id]
+  def goal_activities(benchmark_id, score, goal)
+    raise ArgumentError unless @fixture[benchmark_id]
 
-    if args[:score] && args[:goal]
-      if args[:goal] && ((args[:goal] < 2) || (5 < args[:goal]))
-        raise OutOfBounds.new args[:goal]
-      end
-      if args[:score] && ((args[:score] < 1) || (5 < args[:score]))
-        raise OutOfBounds.new args[:score]
-      end
-      raise InvalidParameter unless args[:score] <= args[:goal]
-
-      return (args[:score] + 1..args[:goal]).reduce([]) do |acc, level|
-        acc.concat @fixture[benchmark_id]['capacity'][level.to_s]
-        acc
-      end
-    elsif args[:level]
-      if args[:level] && ((args[:level] < 2) || (5 < args[:level]))
-        raise OutOfBounds.new args[:level]
-      end
-      return @fixture[benchmark_id]['capacity'][args[:level].to_s]
+    unless goal.between?(2, 5)
+      raise RangeError.new 'goal is not between 2 and 5'
     end
+    unless score.between?(1, 5)
+      raise RangeError.new 'score is not between 2 and 5'
+    end
+    raise ArgumentError.new 'score is > goal' unless score <= goal
 
-    raise InvalidParameter
+    return (score + 1..goal).reduce([]) do |acc, level|
+      acc.concat @fixture[benchmark_id]['capacity'][level.to_s]
+      acc
+    end
+  end
+
+  def capacity_activities(benchmark_id, level)
+    unless level.between?(2, 5)
+      raise RangeError.new 'level is not between 2 and 5'
+    end
+    return @fixture[benchmark_id]['capacity'][level.to_s]
   end
 end

--- a/app/lib/goal_form.rb
+++ b/app/lib/goal_form.rb
@@ -42,8 +42,7 @@ class GoalForm
 
     benchmark_activities =
       benchmark_goals.each.reduce({}) do |acc, (key, value)|
-        acc[key] =
-          benchmarks.activities(key, score: value.score, goal: value.goal)
+        acc[key] = benchmarks.goal_activities(key, value.score, value.goal)
         acc
       end
 

--- a/app/lib/goal_form.rb
+++ b/app/lib/goal_form.rb
@@ -16,12 +16,12 @@ class GoalForm
 
   def self.create_draft_plan!(params, crosswalk, benchmarks_and_activities)
     result =
-      params.keys.reduce({}) do |acc, key|
+      params.keys.reduce({}) do |benchmark_acc, key|
         unless key.start_with?('jee1_') || key.start_with?('jee2_') ||
                key.start_with?('spar_')
-          next acc
+          next benchmark_acc
         end
-        next acc if key.end_with?('_goal')
+        next benchmark_acc if key.end_with?('_goal')
         score = params[key].to_i
         goal = params["#{key}_goal"].to_i
 
@@ -30,14 +30,15 @@ class GoalForm
         benchmark_ids = crosswalk[key]
         benchmark_ids.each do |id|
           activities =
-            (score + 1..goal).reduce([]) do |acc, level|
+            (score + 1..goal).reduce([]) do |activity_acc, level|
               activities = benchmarks_and_activities[id]['capacity'][level.to_s]
-              acc.concat(activities)
-              acc
+              activity_acc.concat(activities)
+              activity_acc
             end
-          acc[id] = activities
+          benchmark_acc[id] = [] unless benchmark_acc[id]
+          benchmark_acc[id].concat(activities)
         end
-        acc
+        benchmark_acc
       end
 
     Plan.create! name: "#{params.fetch(:country)} draft plan",

--- a/app/lib/score_goal.rb
+++ b/app/lib/score_goal.rb
@@ -1,0 +1,18 @@
+class ScoreGoal
+  attr_accessor :score, :goal
+
+  def initialize(params)
+    @score = params.fetch(:score)
+    @goal = params.fetch(:goal)
+  end
+
+  def ==(rside)
+    @score == rside.score && @goal == rside.goal
+  end
+
+  def merge(rside)
+    ScoreGoal.new(
+      score: [@score, rside.score].min, goal: [@goal, rside.goal].max
+    )
+  end
+end

--- a/test/lib/benchmarks_fixture_test.rb
+++ b/test/lib/benchmarks_fixture_test.rb
@@ -4,7 +4,7 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
   test 'reports activities for the requested level' do
     benchmarks = BenchmarksFixture.new
 
-    activities = benchmarks.activities('1.1', level: 2)
+    activities = benchmarks.capacity_activities('1.1', 2)
     assert_equal activities.length, 6
     assert_equal activities[0],
                  'Identify and convene key stakeholders related to the review, formulation and implementation of legislation and policies.'
@@ -13,7 +13,7 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
   test 'calculates activities for a score/goal range' do
     benchmarks = BenchmarksFixture.new
 
-    activities = benchmarks.activities('1.1', score: 2, goal: 4)
+    activities = benchmarks.goal_activities('1.1', 2, 4)
     assert_equal activities.length, 8
     assert_equal activities[0],
                  'Conduct an orientation with relevant stakeholders regarding adjustment in the legislation, laws, regulations, policy and administrative requirements.'
@@ -23,24 +23,12 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
 
   test 'raises an exception if a parameter is out of range' do
     benchmarks = BenchmarksFixture.new
-    assert_raises(OutOfBounds) { || benchmarks.activities '1.1', level: 0 }
-    assert_raises(OutOfBounds) { || benchmarks.activities '1.1', level: 6 }
-    assert_raises(InvalidParameter) { || benchmarks.activities '1.1', goal: 0 }
-    assert_raises(InvalidParameter) { || benchmarks.activities '1.1', score: 0 }
-    assert_raises(OutOfBounds) do ||
-      benchmarks.activities '1.1', score: 6, goal: 5
-    end
-    assert_raises(OutOfBounds) do ||
-      benchmarks.activities '1.1', score: 0, goal: 5
-    end
-    assert_raises(OutOfBounds) do ||
-      benchmarks.activities '1.1', score: 1, goal: 0
-    end
-    assert_raises(OutOfBounds) do ||
-      benchmarks.activities '1.1', score: 1, goal: 6
-    end
-    assert_raises(InvalidParameter) do ||
-      benchmarks.activities '1.1', score: 5, goal: 3
-    end
+    assert_raises(RangeError) { benchmarks.capacity_activities '1.1', 0 }
+    assert_raises(RangeError) { benchmarks.capacity_activities '1.1', 6 }
+    assert_raises(RangeError) { benchmarks.goal_activities '1.1', 6, 5 }
+    assert_raises(RangeError) { benchmarks.goal_activities '1.1', 0, 5 }
+    assert_raises(RangeError) { benchmarks.goal_activities '1.1', 1, 0 }
+    assert_raises(RangeError) { benchmarks.goal_activities '1.1', 1, 6 }
+    assert_raises(ArgumentError) { benchmarks.goal_activities '1.1', 5, 3 }
   end
 end

--- a/test/lib/benchmarks_fixture_test.rb
+++ b/test/lib/benchmarks_fixture_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class BenchmarksFixtureTest < ActiveSupport::TestCase
+  test 'reports activities for the requested level' do
+    benchmarks = BenchmarksFixture.new
+
+    activities = benchmarks.activities('1.1', level: 2)
+    assert_equal activities.length, 6
+    assert_equal activities[0],
+                 'Identify and convene key stakeholders related to the review, formulation and implementation of legislation and policies.'
+  end
+
+  test 'calculates activities for a score/goal range' do
+    benchmarks = BenchmarksFixture.new
+
+    activities = benchmarks.activities('1.1', score: 2, goal: 4)
+    assert_equal activities.length, 8
+    assert_equal activities[0],
+                 'Conduct an orientation with relevant stakeholders regarding adjustment in the legislation, laws, regulations, policy and administrative requirements.'
+    assert_equal activities[7],
+                 'Document these legislation references and relevant interpretations that can assist in IHR implementation.'
+  end
+
+  test 'raises an exception if a parameter is out of range' do
+    benchmarks = BenchmarksFixture.new
+    assert_raises(OutOfBounds) { || benchmarks.activities '1.1', level: 0 }
+    assert_raises(OutOfBounds) { || benchmarks.activities '1.1', level: 6 }
+    assert_raises(InvalidParameter) { || benchmarks.activities '1.1', goal: 0 }
+    assert_raises(InvalidParameter) { || benchmarks.activities '1.1', score: 0 }
+    assert_raises(OutOfBounds) do ||
+      benchmarks.activities '1.1', score: 6, goal: 5
+    end
+    assert_raises(OutOfBounds) do ||
+      benchmarks.activities '1.1', score: 0, goal: 5
+    end
+    assert_raises(OutOfBounds) do ||
+      benchmarks.activities '1.1', score: 1, goal: 0
+    end
+    assert_raises(OutOfBounds) do ||
+      benchmarks.activities '1.1', score: 1, goal: 6
+    end
+    assert_raises(InvalidParameter) do ||
+      benchmarks.activities '1.1', score: 5, goal: 3
+    end
+  end
+end

--- a/test/lib/goal_form_test.rb
+++ b/test/lib/goal_form_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+class GoalFormTest < ActiveSupport::TestCase
+  test 'a simple draft plan' do
+    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
+    benchmarks = BenchmarksFixture.new
+
+    plan =
+      GoalForm.create_draft_plan! (
+                                    {
+                                      'country' => 'Australia',
+                                      'assessment_type' => 'jee1',
+                                      'jee1_ind_p11' => 1,
+                                      'jee1_ind_p11_goal' => 3
+                                    }.with_indifferent_access
+                                  ),
+                                  crosswalk,
+                                  benchmarks
+
+    assert_equal plan[:name], 'Australia draft plan'
+    assert_equal plan[:country], 'Australia'
+    assert_equal plan[:assessment_type], 'jee1'
+    assert_equal plan[:activity_map],
+                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 3) }
+  end
+
+  test 'it gets no activities if the score is already a 5' do
+    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
+    benchmarks = BenchmarksFixture.new
+
+    plan =
+      GoalForm.create_draft_plan! (
+                                    {
+                                      'country' => 'Australia',
+                                      'assessment_type' => 'jee1',
+                                      'jee1_ind_p11' => 5,
+                                      'jee1_ind_p11_goal' => 5
+                                    }.with_indifferent_access
+                                  ),
+                                  crosswalk,
+                                  benchmarks
+
+    assert_equal plan[:name], 'Australia draft plan'
+    assert_equal plan[:country], 'Australia'
+    assert_equal plan[:assessment_type], 'jee1'
+    assert_equal plan[:activity_map], { '1.1' => [] }
+  end
+
+  test 'it gets all of the activities in a range with multiple mappings' do
+    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
+    benchmarks = BenchmarksFixture.new
+
+    plan =
+      GoalForm.create_draft_plan! (
+                                    {
+                                      'country' => 'Australia',
+                                      'assessment_type' => 'jee1',
+                                      'jee1_ind_p11' => 1,
+                                      'jee1_ind_p11_goal' => 3,
+                                      'jee1_ind_p12' => 3,
+                                      'jee1_ind_p12_goal' => 5
+                                    }.with_indifferent_access
+                                  ),
+                                  crosswalk,
+                                  benchmarks
+
+    assert_equal plan[:name], 'Australia draft plan'
+    assert_equal plan[:country], 'Australia'
+    assert_equal plan[:assessment_type], 'jee1'
+    assert_equal plan[:activity_map],
+                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 5) }
+  end
+
+  test 'it gets all of the activities in a range with a gap between multiple mappings' do
+    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
+    benchmarks = BenchmarksFixture.new
+
+    plan =
+      GoalForm.create_draft_plan! (
+                                    {
+                                      'country' => 'Australia',
+                                      'assessment_type' => 'jee1',
+                                      'jee1_ind_p11' => 1,
+                                      'jee1_ind_p11_goal' => 2,
+                                      'jee1_ind_p12' => 3,
+                                      'jee1_ind_p12_goal' => 4
+                                    }.with_indifferent_access
+                                  ),
+                                  crosswalk,
+                                  benchmarks
+
+    assert_equal plan[:name], 'Australia draft plan'
+    assert_equal plan[:country], 'Australia'
+    assert_equal plan[:assessment_type], 'jee1'
+    assert_equal plan[:activity_map],
+                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 4) }
+  end
+end

--- a/test/lib/goal_form_test.rb
+++ b/test/lib/goal_form_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 
 class GoalFormTest < ActiveSupport::TestCase
-  test 'a simple draft plan' do
-    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
-    benchmarks = BenchmarksFixture.new
+  def setup
+    @crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
+    @benchmarks = BenchmarksFixture.new
+  end
 
+  test 'a simple draft plan' do
     plan =
       GoalForm.create_draft_plan! (
                                     {
@@ -14,20 +16,17 @@ class GoalFormTest < ActiveSupport::TestCase
                                       'jee1_ind_p11_goal' => 3
                                     }.with_indifferent_access
                                   ),
-                                  crosswalk,
-                                  benchmarks
+                                  @crosswalk,
+                                  @benchmarks
 
     assert_equal plan[:name], 'Australia draft plan'
     assert_equal plan[:country], 'Australia'
     assert_equal plan[:assessment_type], 'jee1'
     assert_equal plan[:activity_map],
-                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 3) }
+                 { '1.1' => @benchmarks.goal_activities('1.1', 1, 3) }
   end
 
   test 'it gets no activities if the score is already a 5' do
-    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
-    benchmarks = BenchmarksFixture.new
-
     plan =
       GoalForm.create_draft_plan! (
                                     {
@@ -37,8 +36,8 @@ class GoalFormTest < ActiveSupport::TestCase
                                       'jee1_ind_p11_goal' => 5
                                     }.with_indifferent_access
                                   ),
-                                  crosswalk,
-                                  benchmarks
+                                  @crosswalk,
+                                  @benchmarks
 
     assert_equal plan[:name], 'Australia draft plan'
     assert_equal plan[:country], 'Australia'
@@ -47,9 +46,6 @@ class GoalFormTest < ActiveSupport::TestCase
   end
 
   test 'it gets all of the activities in a range with multiple mappings' do
-    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
-    benchmarks = BenchmarksFixture.new
-
     plan =
       GoalForm.create_draft_plan! (
                                     {
@@ -61,20 +57,17 @@ class GoalFormTest < ActiveSupport::TestCase
                                       'jee1_ind_p12_goal' => 5
                                     }.with_indifferent_access
                                   ),
-                                  crosswalk,
-                                  benchmarks
+                                  @crosswalk,
+                                  @benchmarks
 
     assert_equal plan[:name], 'Australia draft plan'
     assert_equal plan[:country], 'Australia'
     assert_equal plan[:assessment_type], 'jee1'
     assert_equal plan[:activity_map],
-                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 5) }
+                 { '1.1' => @benchmarks.goal_activities('1.1', 1, 5) }
   end
 
   test 'it gets all of the activities in a range with a gap between multiple mappings' do
-    crosswalk = JSON.load File.open './app/fixtures/crosswalk.json'
-    benchmarks = BenchmarksFixture.new
-
     plan =
       GoalForm.create_draft_plan! (
                                     {
@@ -86,13 +79,13 @@ class GoalFormTest < ActiveSupport::TestCase
                                       'jee1_ind_p12_goal' => 4
                                     }.with_indifferent_access
                                   ),
-                                  crosswalk,
-                                  benchmarks
+                                  @crosswalk,
+                                  @benchmarks
 
     assert_equal plan[:name], 'Australia draft plan'
     assert_equal plan[:country], 'Australia'
     assert_equal plan[:assessment_type], 'jee1'
     assert_equal plan[:activity_map],
-                 { '1.1' => benchmarks.activities('1.1', score: 1, goal: 4) }
+                 { '1.1' => @benchmarks.goal_activities('1.1', 1, 4) }
   end
 end

--- a/test/lib/score_goal_test.rb
+++ b/test/lib/score_goal_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ScoreGoalTest < ActiveSupport::TestCase
+  test 'merge two ScoreGoals that overlap' do
+    res =
+      ScoreGoal.new(score: 1, goal: 3).merge(ScoreGoal.new(score: 2, goal: 4))
+    assert_equal res, ScoreGoal.new(score: 1, goal: 4)
+  end
+
+  test 'merge two ScoreGoals with no overlap' do
+    res =
+      ScoreGoal.new(score: 1, goal: 3).merge(ScoreGoal.new(score: 3, goal: 4))
+    assert_equal res, ScoreGoal.new(score: 1, goal: 4)
+  end
+
+  test 'merge two ScoreGoals with a gap' do
+    res =
+      ScoreGoal.new(score: 1, goal: 2).merge(ScoreGoal.new(score: 3, goal: 4))
+    assert_equal res, ScoreGoal.new(score: 1, goal: 4)
+  end
+
+  test 'merge two gapped ScoreGoals even in reverse order' do
+    res =
+      ScoreGoal.new(score: 3, goal: 4).merge(ScoreGoal.new(score: 1, goal: 2))
+    assert_equal res, ScoreGoal.new(score: 1, goal: 4)
+  end
+end


### PR DESCRIPTION
Whenever the score and the goal gets adjusted, the application needs to take that into account when choosing the activities for the draft plan.

Also, when two different assessment indicators map to the same benchmark, the activities generate should be all of those to get from the lowest score of the two indicators to the highest goal of the two indicators. To make this easier, I've provided some abstractions to do a bit of the data wrangling out of band of the main controller.