### PR TITLE
Fix the assessment layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -158,3 +158,11 @@ th {
 .alt-header {
     font-family: Pathway Gothic One;
 }
+
+.w-220px {
+    width: 220px;
+}
+
+.w-70px {
+    width: 70px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -159,10 +159,6 @@ th {
     font-family: Pathway Gothic One;
 }
 
-.w-220px {
-    width: 220px;
-}
-
 .w-70px {
     width: 70px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -108,7 +108,7 @@ th {
 }
 
 .navbar {
-  height: 110px;
+  min-height: 110px;
   padding: 27px 35px 27px 35px;
 
   .navbar-brand {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -166,3 +166,13 @@ th {
 .w-70px {
     width: 70px;
 }
+
+.main-content {
+  padding-left: 107px;
+  padding-right: 107px;
+}
+
+.next-button {
+  width: 180px;
+  margin-left: 73px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -163,11 +163,10 @@ th {
     width: 70px;
 }
 
-.main-content {
-  padding-left: 107px;
-  padding-right: 107px;
-}
-
 .next-button {
   width: 180px;
+}
+
+.table-fixed {
+  table-layout: fixed;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,5 +174,4 @@ th {
 
 .next-button {
   width: 180px;
-  margin-left: 73px;
 }

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -1,76 +1,74 @@
 <% if @goals %>
   <%= form_for @goals, url: "/goals/" do |f| %>
-    <div class="container-fluid">
     <%= f.hidden_field :country %> <%= f.hidden_field :assessment_type %>
-      <div class="row py-4">
-        <div class="col-6">
-          <h1 class="alt-header"><%= @goals.assessment_type %> Scores</h1>
+    <div class="row py-4">
+      <div class="col-6">
+        <h1 class="alt-header"><%= @goals.assessment_type %> Scores</h1>
 
-          <p>
-            The scores are pre-populated from our JEE database. The goal is
-            pre-populated by one step up. You can manually change the score or goal to
-            your liking.
-          </p>
-        </div>
-        <div class="col-6 d-flex justify-content-end">
-        <%= render "capacities_widget" %>
-        </div>
+        <p>
+          The scores are pre-populated from our JEE database. The goal is
+          pre-populated by one step up. You can manually change the score or goal to
+          your liking.
+        </p>
       </div>
+      <div class="col-6 d-flex justify-content-end">
+      <%= render "capacities_widget" %>
+      </div>
+    </div>
 
-      <div class="row">
-        <div class="col">
-          <table class="table border-bottom w-100" style="table-layout: fixed">
-            <colgroup>
-              <col width="220px" />
-              <col />
-              <col width="90px" />
-              <col width="90px" />
-            </colgroup>
-            <thead>
-              <tr class="jee-table-header">
-                <th>Technical Areas</th>
-                <th>Indicators</th>
-                <th>Score</th>
-                <th>Goal</th>
+    <div class="row">
+      <div class="col">
+        <table class="table border-bottom w-100" style="table-layout: fixed">
+          <colgroup>
+            <col width="220px" />
+            <col />
+            <col width="90px" />
+            <col width="90px" />
+          </colgroup>
+          <thead>
+            <tr class="jee-table-header">
+              <th>Technical Areas</th>
+              <th>Indicators</th>
+              <th>Score</th>
+              <th>Goal</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
+              <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
+              <tr>
+                <% indicator = technical_area['indicators'][0] %>
+                <th
+                  class="border-right"
+                  scope="row"
+                  rowspan="<%= technical_area['indicators'].count %>"
+                >
+                  <%= @data_dictionary[technical_area_id] %>
+                </th>
+                <td class="border-right"><%= @data_dictionary[indicator] %></td>
+                <td><%= f.number_field(indicator, class: "w-70px") %></td>
+                <td>
+                  <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
+                </td>
               </tr>
-            </thead>
 
-            <tbody>
-              <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
-                <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
+              <% technical_area['indicators'].drop(1).each do |indicator| %>
                 <tr>
-                  <% indicator = technical_area['indicators'][0] %>
-                  <th
-                    class="border-right"
-                    scope="row"
-                    rowspan="<%= technical_area['indicators'].count %>"
-                  >
-                    <%= @data_dictionary[technical_area_id] %>
-                  </th>
                   <td class="border-right"><%= @data_dictionary[indicator] %></td>
                   <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                  <td>
-                    <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
-                  </td>
+                  <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
                 </tr>
-
-                <% technical_area['indicators'].drop(1).each do |indicator| %>
-                  <tr>
-                    <td class="border-right"><%= @data_dictionary[indicator] %></td>
-                    <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                    <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
-                  </tr>
-                <% end %>
               <% end %>
-            </tbody>
-          </table>
-        </div>
+            <% end %>
+          </tbody>
+        </table>
       </div>
+    </div>
 
-      <div class="row">
-        <div class="col d-flex justify-content-end">
-          <%= f.submit "Next", class: "btn btn-primary next-button" %>
-        </div>
+    <div class="row">
+      <div class="col d-flex justify-content-end">
+        <%= f.submit "Next", class: "btn btn-primary next-button" %>
       </div>
     </div>
   <% end %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -18,7 +18,7 @@
 
     <div class="row">
       <div class="col">
-        <table class="table border-bottom w-100" style="table-layout: fixed">
+        <table class="table table-fixed border-bottom w-100">
           <colgroup>
             <col width="220px" />
             <col />

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -68,7 +68,7 @@
 
     <div class="row">
       <div class="col-10"></div>
-      <div class="col-2"><%= f.submit "Next", class: "btn btn-primary" %></div>
+      <div class="col-2"><%= f.submit "Next", class: "btn btn-primary next-button" %></div>
     </div>
   <% end %>
 <% else %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -13,45 +13,56 @@
             </div>
         </div>
 
-        <div class="row">
-            <div class="col">
-            <table class="table border-bottom">
-                <thead>
-                <tr class="jee-table-header">
-                    <th scope="col" class="col-3"> Technical Areas </th>
-                    <th scope="col" class="col-7"> Indicators </th>
-                    <th scope="col" class="col-1"> Score </th>
-                    <th scope="col" class="col-1"> Goal </th>
-                </tr>
-                </thead>
+<div class="row">
+  <div class="col">
+    <table class="table border-bottom w-100" style="table-layout: fixed">
+      <colgroup>
+        <col width="220px">
+        <col>
+        <col width="90px">
+        <col width="90px">
+      </colgroup>
+      <thead>
+        <tr class="jee-table-header">
+          <th>Technical Areas</th>
+          <th>Indicators</th>
+          <th>Score</th>
+          <th>Goal</th>
+        </tr>
+      </thead>
 
-                <tbody>
-                <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
-                    <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
-                    <tr>
-                        <% indicator = technical_area['indicators'][0] %>
-                        <th class="border-right"
-                            scope="row"
-                            rowspan="<%= technical_area['indicators'].count %>">
-                            <%= @data_dictionary[technical_area_id] %>
-                        </th>
-                        <td> <%= @data_dictionary[indicator] %> </td>
-                        <td> <%= f.number_field(indicator) %> </td>
-                        <td> <%= f.number_field("#{indicator}_goal") %> </td>
-                    </tr>
+      <tbody>
+        <% @assessments[@goals.assessment_type]['technical_area_order'].each do
+        |technical_area_id| %> <% technical_area =
+        @assessments[@goals.assessment_type]['technical_areas'][technical_area_id]
+        %>
+        <tr>
+          <% indicator = technical_area['indicators'][0] %>
+          <th
+            class="border-right"
+            scope="row"
+            rowspan="<%= technical_area['indicators'].count %>"
+          >
+            <%= @data_dictionary[technical_area_id] %>
+          </th>
+          <td><%= @data_dictionary[indicator] %></td>
+          <td><%= f.number_field(indicator, class: "w-70px") %></td>
+          <td>
+            <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
+          </td>
+        </tr>
 
-                    <% technical_area['indicators'].drop(1).each do |indicator| %>
-                    <tr>
-                        <td> <%= @data_dictionary[indicator] %> </td>
-                        <td> <%= f.number_field(indicator) %> </td>
-                        <td> <%= f.number_field("#{indicator}_goal") %> </td>
-                    </tr>
-                    <% end %>
-                <% end %>
-                </tbody>
-            </table>
-            </div>
-        </div>
+        <% technical_area['indicators'].drop(1).each do |indicator| %>
+        <tr>
+          <td><%= @data_dictionary[indicator] %></td>
+          <td><%= f.number_field(indicator, class: "w-70px") %></td>
+          <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
+        </tr>
+        <% end %> <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
 
             <div class="row">
                 <div class="col-10"></div>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -1,77 +1,78 @@
 <% if @goals %>
-    <%= form_for @goals, url: "/goals/" do |f| %>
-        <%= f.hidden_field :country %>
-        <%= f.hidden_field :assessment_type %>
-        <div class="row py-4">
-            <div class="col-6">
-            <h1 class="alt-header"> <%= @goals.assessment_type %> Scores </h1>
+  <%= form_for @goals, url: "/goals/" do |f| %>
+    <%= f.hidden_field :country %> <%= f.hidden_field :assessment_type %>
+    <div class="row py-4">
+      <div class="col-6">
+        <h1 class="alt-header"><%= @goals.assessment_type %> Scores</h1>
 
-            <p> The scores are pre-populated from our JEE database. The goal is pre-populated by one step up. You can manually change the score or goal to your liking. </p>
-            </div>
-            <div class="col-6">
-              <%= render "capacities_widget" %>
-            </div>
-        </div>
-
-<div class="row">
-  <div class="col">
-    <table class="table border-bottom w-100" style="table-layout: fixed">
-      <colgroup>
-        <col width="220px">
-        <col>
-        <col width="90px">
-        <col width="90px">
-      </colgroup>
-      <thead>
-        <tr class="jee-table-header">
-          <th>Technical Areas</th>
-          <th>Indicators</th>
-          <th>Score</th>
-          <th>Goal</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @assessments[@goals.assessment_type]['technical_area_order'].each do
-        |technical_area_id| %> <% technical_area =
-        @assessments[@goals.assessment_type]['technical_areas'][technical_area_id]
-        %>
-        <tr>
-          <% indicator = technical_area['indicators'][0] %>
-          <th
-            class="border-right"
-            scope="row"
-            rowspan="<%= technical_area['indicators'].count %>"
-          >
-            <%= @data_dictionary[technical_area_id] %>
-          </th>
-          <td><%= @data_dictionary[indicator] %></td>
-          <td><%= f.number_field(indicator, class: "w-70px") %></td>
-          <td>
-            <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
-          </td>
-        </tr>
-
-        <% technical_area['indicators'].drop(1).each do |indicator| %>
-        <tr>
-          <td><%= @data_dictionary[indicator] %></td>
-          <td><%= f.number_field(indicator, class: "w-70px") %></td>
-          <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
-        </tr>
-        <% end %> <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-            <div class="row">
-                <div class="col-10"></div>
-                <div class="col-2"><%= f.submit "Next", class: "btn btn-primary" %></div>
-            </div>
-        </div>
-    <% end %>
-<% else %>
-    <div class="col">
-      <div>No assessment available</div>
+        <p>
+          The scores are pre-populated from our JEE database. The goal is
+          pre-populated by one step up. You can manually change the score or goal to
+          your liking.
+        </p>
+      </div>
+      <div class="col-6">
+        <%= render "capacities_widget" %>
+      </div>
     </div>
+
+    <div class="row">
+      <div class="col">
+        <table class="table border-bottom w-100" style="table-layout: fixed">
+          <colgroup>
+            <col width="220px" />
+            <col />
+            <col width="90px" />
+            <col width="90px" />
+          </colgroup>
+          <thead>
+            <tr class="jee-table-header">
+              <th>Technical Areas</th>
+              <th>Indicators</th>
+              <th>Score</th>
+              <th>Goal</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
+              <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
+              <tr>
+                <% indicator = technical_area['indicators'][0] %>
+                <th
+                  class="border-right"
+                  scope="row"
+                  rowspan="<%= technical_area['indicators'].count %>"
+                >
+                  <%= @data_dictionary[technical_area_id] %>
+                </th>
+                <td class="border-right"><%= @data_dictionary[indicator] %></td>
+                <td><%= f.number_field(indicator, class: "w-70px") %></td>
+                <td>
+                  <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
+                </td>
+              </tr>
+
+              <% technical_area['indicators'].drop(1).each do |indicator| %>
+                <tr>
+                  <td class="border-right"><%= @data_dictionary[indicator] %></td>
+                  <td><%= f.number_field(indicator, class: "w-70px") %></td>
+                  <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
+                </tr>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-10"></div>
+      <div class="col-2"><%= f.submit "Next", class: "btn btn-primary" %></div>
+    </div>
+  <% end %>
+<% else %>
+  <div class="col">
+    <div>No assessment available</div>
+  </div>
 <% end %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -1,74 +1,77 @@
 <% if @goals %>
   <%= form_for @goals, url: "/goals/" do |f| %>
+    <div class="container-fluid">
     <%= f.hidden_field :country %> <%= f.hidden_field :assessment_type %>
-    <div class="row py-4">
-      <div class="col-6">
-        <h1 class="alt-header"><%= @goals.assessment_type %> Scores</h1>
+      <div class="row py-4">
+        <div class="col-6">
+          <h1 class="alt-header"><%= @goals.assessment_type %> Scores</h1>
 
-        <p>
-          The scores are pre-populated from our JEE database. The goal is
-          pre-populated by one step up. You can manually change the score or goal to
-          your liking.
-        </p>
-      </div>
-      <div class="col-6">
+          <p>
+            The scores are pre-populated from our JEE database. The goal is
+            pre-populated by one step up. You can manually change the score or goal to
+            your liking.
+          </p>
+        </div>
+        <div class="col-6 d-flex justify-content-end">
         <%= render "capacities_widget" %>
+        </div>
       </div>
-    </div>
 
-    <div class="row">
-      <div class="col">
-        <table class="table border-bottom w-100" style="table-layout: fixed">
-          <colgroup>
-            <col width="220px" />
-            <col />
-            <col width="90px" />
-            <col width="90px" />
-          </colgroup>
-          <thead>
-            <tr class="jee-table-header">
-              <th>Technical Areas</th>
-              <th>Indicators</th>
-              <th>Score</th>
-              <th>Goal</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
-              <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
-              <tr>
-                <% indicator = technical_area['indicators'][0] %>
-                <th
-                  class="border-right"
-                  scope="row"
-                  rowspan="<%= technical_area['indicators'].count %>"
-                >
-                  <%= @data_dictionary[technical_area_id] %>
-                </th>
-                <td class="border-right"><%= @data_dictionary[indicator] %></td>
-                <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                <td>
-                  <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
-                </td>
+      <div class="row">
+        <div class="col">
+          <table class="table border-bottom w-100" style="table-layout: fixed">
+            <colgroup>
+              <col width="220px" />
+              <col />
+              <col width="90px" />
+              <col width="90px" />
+            </colgroup>
+            <thead>
+              <tr class="jee-table-header">
+                <th>Technical Areas</th>
+                <th>Indicators</th>
+                <th>Score</th>
+                <th>Goal</th>
               </tr>
+            </thead>
 
-              <% technical_area['indicators'].drop(1).each do |indicator| %>
+            <tbody>
+              <% @assessments[@goals.assessment_type]['technical_area_order'].each do |technical_area_id| %>
+                <% technical_area = @assessments[@goals.assessment_type]['technical_areas'][technical_area_id] %>
                 <tr>
+                  <% indicator = technical_area['indicators'][0] %>
+                  <th
+                    class="border-right"
+                    scope="row"
+                    rowspan="<%= technical_area['indicators'].count %>"
+                  >
+                    <%= @data_dictionary[technical_area_id] %>
+                  </th>
                   <td class="border-right"><%= @data_dictionary[indicator] %></td>
                   <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                  <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
+                  <td>
+                    <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
+                  </td>
                 </tr>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
 
-    <div class="row">
-      <div class="col-10"></div>
-      <div class="col-2"><%= f.submit "Next", class: "btn btn-primary next-button" %></div>
+                <% technical_area['indicators'].drop(1).each do |indicator| %>
+                  <tr>
+                    <td class="border-right"><%= @data_dictionary[indicator] %></td>
+                    <td><%= f.number_field(indicator, class: "w-70px") %></td>
+                    <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col d-flex justify-content-end">
+          <%= f.submit "Next", class: "btn btn-primary next-button" %>
+        </div>
+      </div>
     </div>
   <% end %>
 <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   <body>
     <%= render "layouts/header" %>
     <div class="container-fluid">
-      <div class="main-content">
+      <div class="offset-1 col-10">
         <%= yield %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,9 @@
   <body>
     <%= render "layouts/header" %>
     <div class="container-fluid">
-    <%= yield %>
+      <div class="main-content">
+        <%= yield %>
+      </div>
     </div>
     <% if controller_name == "landing" %>
       <%= render "layouts/landing_page_footer" %>


### PR DESCRIPTION
Browser differences meant that what worked on Firefox did not work on Chrome or Safari. These changes get the assessment laid out correctly on all browsers.

# Screenshots

Safari: <img width="1693" alt="Screen Shot 2019-08-14 at 3 54 40 PM" src="https://user-images.githubusercontent.com/8534888/63051830-f627cf80-beab-11e9-9f9b-6269f40a08e7.png">

Chrome: <img width="1357" alt="Screen Shot 2019-08-14 at 3 56 06 PM" src="https://user-images.githubusercontent.com/8534888/63051881-0cce2680-beac-11e9-8486-02051095f31a.png">

# Stories
* Resolves https://www.pivotaltracker.com/story/show/167884416
