### PR TITLE
Goal form validation behavior

### DIFF
--- a/app/javascript/src/controllers/score_controller.js
+++ b/app/javascript/src/controllers/score_controller.js
@@ -21,7 +21,6 @@ export default class extends Controller {
 
     if (isGoal) {
       const score_field = document.getElementById(field.id.replace("_goal", ""))
-      console.log("score_field", score_field)
       if (Number(score_field.value) > Number(field.value)) {
         field.setCustomValidity("invalid")
       }

--- a/app/javascript/src/controllers/score_controller.js
+++ b/app/javascript/src/controllers/score_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "stimulus"
+
+const SPAR_SCORES = [0, 20, 40, 60, 80, 100]
+const JEE_SCORES = [0, 1, 2, 3, 4, 5]
+
+export default class extends Controller {
+  static targets = ["form"]
+
+  validate(e){
+    const { currentTarget: field } = e
+    const assessmentType = this.formTarget.getAttribute("data-type")
+    const scores = assessmentType.match(/spar/) ? SPAR_SCORES : JEE_SCORES
+    const isGoal = field.getAttribute("data-goal") === "true"
+    field.setCustomValidity("")
+
+    if (field.value.length === 0) {
+      field.setCustomValidity("invalid")
+    } else if (!scores.includes(Number(field.value))) {
+      field.setCustomValidity("invalid")
+    }
+
+    if (isGoal) {
+      const score_field = document.getElementById(field.id.replace("_goal", ""))
+      console.log("score_field", score_field)
+      if (Number(score_field.value) > Number(field.value)) {
+        field.setCustomValidity("invalid")
+      }
+    } else {
+      const goal_field = document.getElementById(field.id + "_goal")
+      if (Number(goal_field.value) < Number(field.value)) {
+        field.setCustomValidity("invalid")
+      }
+    }
+
+    field.parentElement.classList.add("was-validated")
+  }
+
+  submit(e) {
+    const { currentTarget: form } = e
+    if (form.checkValidity() === false) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    form.classList.add('was-validated');
+  }
+}

--- a/app/javascript/src/controllers/score_controller.js
+++ b/app/javascript/src/controllers/score_controller.js
@@ -4,7 +4,7 @@ const SPAR_SCORES = [0, 20, 40, 60, 80, 100]
 const JEE_SCORES = [0, 1, 2, 3, 4, 5]
 
 export default class extends Controller {
-  static targets = ["form"]
+  static targets = ["form", "submitButton"]
 
   validate(e){
     const { currentTarget: field } = e
@@ -33,6 +33,12 @@ export default class extends Controller {
     }
 
     field.parentElement.classList.add("was-validated")
+
+    if (this.formTarget.checkValidity() === false) {
+      this.submitButtonTarget.setAttribute("disabled", "disabled")
+    } else {
+      this.submitButtonTarget.removeAttribute("disabled")
+    }
   }
 
   submit(e) {

--- a/app/views/goals/_validated_field.html.erb
+++ b/app/views/goals/_validated_field.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <%= f.number_field field_name, data: { action: "change->score#validate", goal: field_name.match?("goal")  }, class: "form-control w-70px", required: true %>
+  <div class="invalid-feedback">
+    Must be a valid capacity score
+  </div>
+</div>
+

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -1,5 +1,5 @@
 <% if @goals %>
-  <%= form_for @goals, url: "/goals/" do |f| %>
+  <%= form_for @goals, url: "/goals/", html: {novalidate: true, class: "needs-validation", data: { controller: "score", action: "submit->score#submit", target: "score.form", type: @goals.assessment_type }} do |f| %>
     <%= f.hidden_field :country %> <%= f.hidden_field :assessment_type %>
     <div class="row py-4">
       <div class="col-6">
@@ -47,17 +47,15 @@
                   <%= @data_dictionary[technical_area_id] %>
                 </th>
                 <td class="border-right"><%= @data_dictionary[indicator] %></td>
-                <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                <td>
-                  <%= f.number_field("#{indicator}_goal", class: "w-70px") %>
-                </td>
+                <td><%= render "validated_field", field_name: indicator, f: f %></td>
+                <td><%= render "validated_field", field_name: "#{indicator}_goal", f: f %></td>
               </tr>
 
               <% technical_area['indicators'].drop(1).each do |indicator| %>
                 <tr>
                   <td class="border-right"><%= @data_dictionary[indicator] %></td>
-                  <td><%= f.number_field(indicator, class: "w-70px") %></td>
-                  <td><%= f.number_field("#{indicator}_goal", class: "w-70px") %></td>
+                  <td><%= render "validated_field", field_name: indicator, f: f %></td>
+                  <td><%= render "validated_field", field_name: "#{indicator}_goal", f: f %></td>
                 </tr>
               <% end %>
             <% end %>
@@ -65,7 +63,6 @@
         </table>
       </div>
     </div>
-
     <div class="row">
       <div class="col d-flex justify-content-end">
         <%= f.submit "Next", class: "btn btn-primary next-button" %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -65,7 +65,7 @@
     </div>
     <div class="row">
       <div class="col d-flex justify-content-end">
-        <%= f.submit "Next", class: "btn btn-primary next-button" %>
+        <%= f.submit "Next", class: "btn btn-primary next-button", data: { target: "score.submitButton"} %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
This PR adds validation behavior to the goals form:

* Scores and goals are validated to be one of the allowed score values for a given assessment type
* Scores and goals are validated in relation to each other (goal >= score)
* The "next" button is disabled if any input is invalid

Implementation notes:

I followed the recommendations set out in https://getbootstrap.com/docs/4.0/components/forms/#custom-styles to circumvent default browser behavior.

<img width="341" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1207345/63050953-430aa680-beaa-11e9-92b1-8dbee6ddd756.png">
<img width="354" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1207345/63050984-5158c280-beaa-11e9-8b80-61f4d27f3ebd.png">
