### PR TITLE
add a min-width to capacity score widget so it stays integrated

### DIFF
--- a/app/assets/stylesheets/scores_widget.scss
+++ b/app/assets/stylesheets/scores_widget.scss
@@ -1,6 +1,7 @@
 .widget-container {
   height: 156px;
   width: 560px;
+  min-width: 560px;
   padding-top: 15px;
   strong {
     font-family: Karla;
@@ -21,7 +22,7 @@
       font-size: 12px;
 
       &::before {
-        content: '';
+        content: "";
         position: absolute;
         top: 13px;
         left: -86px;

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -11,7 +11,7 @@
           your liking.
         </p>
       </div>
-      <div class="col-6 d-flex justify-content-end">
+      <div class="col-lg-6 col-md-12 d-flex justify-content-end">
       <%= render "capacities_widget" %>
       </div>
     </div>


### PR DESCRIPTION
Currently, when the screen width reduces, the widget starts to disintegrate(!). This PR places a min-width on the widget.