### PR TITLE
use svg extension in `image_path`

### DIFF
--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -31,17 +31,17 @@
                     <td class="py-4"> <%= plan.updated_at.strftime "%B %d, %Y" %> </td>
                     <td class="py-4 text-secondary">
                         <%= render 'shared/icon',
-                            image_name: "ico-download",
+                            image_name: "ico-download.svg",
                             text: "Download XLS" %>
                     </td>
                     <td class="py-4 text-secondary">
                         <%= render 'shared/icon',
-                            image_name: "ico-print",
+                            image_name: "ico-print.svg",
                             text: "Print" %>
                     </td>
                     <td class="py-4 text-secondary">
                         <%= render 'shared/icon',
-                            image_name: "ico-analyze",
+                            image_name: "ico-analyze.svg",
                             text: "Analyze" %>
                     </td>
                 </tr>


### PR DESCRIPTION
For some reason, not including .svg prevents Heroku from being able to find the image. Locally it works both ways.

# Stories

Currently blocks acceptance for a few stories.

