### PR TITLE
Plan access

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,11 +1,14 @@
 class PlansController < ApplicationController
+  before_action :authenticate_user!, only: [:index]
+  before_action :check_ownership, except: [:index]
+
   def show
     @benchmarks = BenchmarksFixture.new
     @plan = Plan.find_by_id!(params.fetch(:id))
   end
 
   def index
-    @plans = Plan.all
+    @plans = current_user.plans.order(updated_at: :desc)
   end
 
   def update
@@ -22,6 +25,20 @@ class PlansController < ApplicationController
   end
 
   private
+
+  def check_ownership
+    if current_user
+      if current_user.plan_ids.exclude?(params.fetch(:id).to_i)
+        flash[:alert] = "You are not allowed to access this plan"
+        redirect_to root_path
+      end
+    else
+      unless params.fetch(:id).to_i == session[:plan_id]
+        flash[:alert] = "You are not allowed to access this plan"
+        redirect_to root_path
+      end
+    end
+  end
 
   def plan_params
     params.require(:plan).permit(:name, :activity_map)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -26,17 +26,17 @@ class PlansController < ApplicationController
 
   private
 
+  def alert_and_redirect
+    flash[:alert] = "You are not allowed to access this plan"
+    redirect_to root_path
+  end
+
   def check_ownership
+    plan_id = params.fetch(:id).to_i
     if current_user
-      if current_user.plan_ids.exclude?(params.fetch(:id).to_i)
-        flash[:alert] = "You are not allowed to access this plan"
-        redirect_to root_path
-      end
+      alert_and_redirect if current_user.plan_ids.exclude?(plan_id)
     else
-      unless params.fetch(:id).to_i == session[:plan_id]
-        flash[:alert] = "You are not allowed to access this plan"
-        redirect_to root_path
-      end
+      alert_and_redirect unless plan_id == session[:plan_id]
     end
   end
 

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -1,0 +1,106 @@
+require "minitest/autorun"
+
+def create_draft_plan_stub
+  plan = Plan.create(name: "test plan", activity_map: [])
+  GoalForm.stub :create_draft_plan!, plan do
+    yield plan.id
+  end
+end
+
+class PlansControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "plan#show redirects logged out user without session[:plan_id]" do
+    get plan_path(1)
+    assert_response :redirect
+  end
+
+  test "redirects logged out user with mismatched session[:plan_id]" do
+    create_draft_plan_stub do |plan_id|
+      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
+      get plan_path("another plan")
+      assert_response :redirect
+    end
+  end
+
+  test "logged out user can access a plan matching session[:plan_id]" do
+    create_draft_plan_stub do |plan_id|
+      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
+      get plan_path(plan_id)
+      assert_response :ok
+    end
+  end
+
+  test "logged in user can see their plan" do
+    plan = Plan.create(name: "a plan", activity_map: [])
+    user = User.new(email: 'test@example.com')
+    user.plans << plan
+    sign_in user
+    get plan_path(plan.id)
+    assert_response :ok
+  end
+
+  test "logged in user can't see someone else's plan" do
+    plan = Plan.create(name: "a plan", activity_map: [])
+    user = User.new(email: 'test@example.com')
+    sign_in user
+    get plan_path(plan.id)
+    assert_response :redirect
+  end
+
+  test "logged in user can update their plan" do
+    plan = Plan.create(name: "a draft plan", activity_map: [])
+    user = User.new(email: 'test@example.com')
+    user.plans << plan
+    sign_in user
+    put plan_path(plan.id), params: { plan: {name: "the plan", activity_map: "[]"}}
+    assert_equal Plan.find_by_name("the plan").id, plan.id
+  end
+
+  test "logged in user can't update someone else's plan" do
+    plan = Plan.create(name: "a draft plan", activity_map: [])
+    user = User.new(email: 'test@example.com')
+    sign_in user
+    put plan_path(plan.id), params: { plan: {name: "the plan", activity_map: "[]"}}
+    assert_redirected_to root_path
+    assert_equal Plan.where(name: "the plan").count, 0
+  end
+
+  test "logged out user can't update a plan with id != session[:plan_id]" do
+    create_draft_plan_stub do |plan_id|
+      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
+      put plan_path("another plan"), params: { plan: { name: "different" }}
+      assert_redirected_to root_path
+    end
+  end
+
+  test "logged out user can update a plan with id == session[:plan_id]" do
+    create_draft_plan_stub do |plan_id|
+      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
+      put plan_path(plan_id), params: { plan: { name: "different", activity_map: "[]" }}
+      assert_redirected_to new_user_session_path
+      assert_equal Plan.find_by_name("different").id, plan_id
+    end
+  end
+
+  test "logged out user can't see a list of plans" do
+    get plans_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "logged in user sees a list of their plans" do
+    user = User.create!(email: 'test@example.com', password: "123455", role: "Donor")
+    plan1 = Plan.create!(name: "owned plan", activity_map: [])
+    user.plans << plan1
+    Plan.create!(name: "orphan", activity_map: [])
+
+    sign_in user
+    get plans_path
+    assert_response :ok
+    assert_select ".plan-entry", 1
+
+    user.plans.first.destroy
+    get plans_path
+    assert_select ".plan-entry", 0
+  end
+end

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -3,6 +3,7 @@ require "minitest/autorun"
 def create_draft_plan_stub
   plan = Plan.create(name: "test plan", activity_map: [])
   GoalForm.stub :create_draft_plan!, plan do
+    post goals_url, params: {goal_form: { assessment_type: "jee1"}}
     yield plan.id
   end
 end
@@ -17,7 +18,6 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test "redirects logged out user with mismatched session[:plan_id]" do
     create_draft_plan_stub do |plan_id|
-      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
       get plan_path("another plan")
       assert_response :redirect
     end
@@ -25,7 +25,6 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test "logged out user can access a plan matching session[:plan_id]" do
     create_draft_plan_stub do |plan_id|
-      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
       get plan_path(plan_id)
       assert_response :ok
     end
@@ -68,7 +67,6 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test "logged out user can't update a plan with id != session[:plan_id]" do
     create_draft_plan_stub do |plan_id|
-      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
       put plan_path("another plan"), params: { plan: { name: "different" }}
       assert_redirected_to root_path
     end
@@ -76,7 +74,6 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test "logged out user can update a plan with id == session[:plan_id]" do
     create_draft_plan_stub do |plan_id|
-      post goals_url, params: {goal_form: { assessment_type: "jee1"}}
       put plan_path(plan_id), params: { plan: { name: "different", activity_map: "[]" }}
       assert_redirected_to new_user_session_path
       assert_equal Plan.find_by_name("different").id, plan_id


### PR DESCRIPTION
* A logged out user can only read and update a plan if its id matches `session[:plan_id]`
* A logged in user can only access plans they own
* The plans index route is only available to logged in users.

# Stories
Resolves
* https://www.pivotaltracker.com/story/show/167604939
* https://www.pivotaltracker.com/story/show/167977616