### PR TITLE
Try to set the confirmation url protocol to https

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: ENV['BENCHMARKS_HOST'] }
+  config.action_mailer.default_url_options = {
+    protocol: 'https', host: ENV['BENCHMARKS_HOST']
+  }
 
   ActionMailer::Base.delivery_method = :smtp
   ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
This is a follow-on to a previous PR. In addition to no longer allowing http connections (as done in the previous PR), the application will now email out confirmation URLs with https protocols instead of just http.

For lack of anywhere better to test it, I pushed this to staging.

# Stories

* Resolves https://www.pivotaltracker.com/story/show/168226839