### PR TITLE
Set up attack throttling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'rake'
 
@@ -32,10 +32,11 @@ gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 gem 'webpacker', '~> 4.x'
 gem 'devise'
+gem 'rack-attack'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
 end
 
 group :development do
@@ -52,4 +53,3 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'cuprite'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-attack (6.1.0)
+      rack (>= 1.0, < 3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -224,6 +226,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  rack-attack
   rails (~> 5.2.3)
   rake
   rubyXL

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Src
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.assets.enabled = false
+    config.middleware.use Rack::Attack
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,74 @@
+# Copied from https://github.com/kickstarter/rack-attack/blob/master/docs/example_configuration.md
+
+class Rack::Attack
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blocklisting and
+  # safelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  throttle('req/ip', limit: 10, period: 5.minutes, &:ip)
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /users/sign_in by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle('logins/ip', limit: 5, period: 20.seconds) do |req|
+    req.ip if req.path == '/users/sign_in' && req.post?
+  end
+
+  # Throttle POST requests to /users/sign_in by user[email] param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  throttle('logins/email', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/users/sign_in' && req.post?
+      # return the email if present, nil otherwise
+      req.params['user[email]'].presence
+    end
+  end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_response = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,7 +25,7 @@ class Rack::Attack
   # Throttle all requests by IP (60rpm)
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-  throttle('req/ip', limit: 10, period: 5.minutes, &:ip)
+  throttle('req/ip', limit: 300, period: 5.minutes, &:ip)
 
   ### Prevent Brute-Force Login Attacks ###
 


### PR DESCRIPTION
This adds the rack-attack gem and then uses some pretty mundane settings to mitigate attacks.

Each IP address is limited to 300 requests in a five minute period just to avoid DOSing.

Attempts to authenticate are limited to 5 requests in a twenty second period to prevent password attacks.

# Stories

Resolves: https://www.pivotaltracker.com/story/show/168084986

