### PR TITLE
add sentry and setup a basic config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 gem 'webpacker', '~> 4.x'
 gem 'devise'
+gem 'sentry-raven'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       warden (~> 1.2.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -113,6 +115,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.1)
+    multipart-post (2.1.1)
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -172,6 +175,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sentry-raven (2.11.0)
+      faraday (>= 0.7.6, < 1.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -227,6 +232,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rake
   rubyXL
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.environments = %w[production]
+end


### PR DESCRIPTION
# Screenshots
I configured it such that it would only report errors on "production", but I did test that the reporting works locally:

<img width="1185" alt="Screen Shot 46" src="https://user-images.githubusercontent.com/1207345/64283838-3d8f0200-cf26-11e9-9424-49312d2b275f.png">

# new environment variable

Sentry requires the `SENTRY_DSN` env var to be set. If it's not set, error reporting does not happen (the app continues to work as expected though). I will set this variable on staging and production.

# Async

Currently, Sentry reports errors synchronously, which I think meets our needs. It can be configured such that it sends errors to a background job processor, but I've chosen to omit that for now. Happy to consider it if you think it's necessary though.

# other config options

We have a few options available here: https://docs.sentry.io/clients/ruby/config/

Lmk if you'd like me to add any of them.

# Stories
https://www.pivotaltracker.com/story/show/168115697

