### PR TITLE
Create assessment selection placeholders

### DIFF
--- a/app/helpers/country_selection_helper.rb
+++ b/app/helpers/country_selection_helper.rb
@@ -10,7 +10,9 @@ module CountrySelectionHelper
     assessment_structure = JSON.load File.open './app/fixtures/assessments.json'
     assessments = Assessment.pluck(:country, :assessment_type)
     selectables =
-      assessments.reduce({}) do |acc, (country, assessment_type)|
+      assessments.reduce(
+        { '-- Select One --' => [] }
+      ) do |acc, (country, assessment_type)|
         acc[country] = [] unless acc[country]
         acc[country].push(
           {

--- a/app/javascript/src/controllers/assessment_selection_controller.js
+++ b/app/javascript/src/controllers/assessment_selection_controller.js
@@ -3,10 +3,12 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [
     "assessmentTypes",
+    "getStartedButton",
     "selectedCountry",
     "selectables",
     "selectedCountryName",
-    "selectedCountryModal"
+    "selectedCountryModal",
+    "submitForm"
   ]
 
   connect() {
@@ -19,21 +21,27 @@ export default class extends Controller {
   }
 
   openModalValidated(e) {
-    if (this.validateCountry()) this.openModal(e)
+    if (this.isCountryValid()) this.openModal(e)
   }
 
-  validateCountry() {
+  isCountryValid() {
     return this.selectedCountryTarget.value !== "-- Select One --"
   }
 
-  validateAssessment() {
+  isAssessmentTypeValid() {
     return (
       this.assessmentTypesTarget.selectedOptions[0].value !== "-- Select One --"
     )
   }
 
+  validateAndEnableGetStarted(e) {
+    this.getStartedButtonTarget.disabled = !this.isCountryValid()
+  }
+
   validateAndEnableNext(e) {
-    $("#btn-next").prop('disabled', !(this.validateCountry() && this.validateAssessment()))
+    this.submitFormTarget.disabled = !(
+      this.isCountryValid() && this.isAssessmentTypeValid()
+    )
   }
 
   selectCountry(e) {
@@ -54,8 +62,6 @@ export default class extends Controller {
 
     if (this.hasSelectedCountryModalTarget)
       this.selectedCountryModalTarget.value = countryName
-
-    $("#btn-get-started").prop("disabled", !this.validateCountry())
   }
 
   selectCountryAndOpen(e) {

--- a/app/javascript/src/controllers/assessment_selection_controller.js
+++ b/app/javascript/src/controllers/assessment_selection_controller.js
@@ -18,6 +18,18 @@ export default class extends Controller {
     $("#assessment-selection-modal").modal()
   }
 
+  openModalValidated(e) {
+    if (this.validateCountry()) this.openModal(e)
+  }
+
+  validateCountry() {
+    return this.selectedCountryTarget.value !== "-- Select One --"
+  }
+
+  //validateForm() {
+  //return this.selectedCountryTarget.value !== "-- Select One --"
+  //}
+
   selectCountry(e) {
     const countryName = this.selectedCountryTarget.value
     const assessmentTypes = this.selectables[countryName]
@@ -34,6 +46,15 @@ export default class extends Controller {
 
     if (this.hasSelectedCountryModalTarget)
       this.selectedCountryModalTarget.value = countryName
+
+    if (this.validateCountry())
+      $("#btn-get-started")
+        .removeClass("bg-secondary")
+        .addClass("bg-green")
+    else
+      $("#btn-get-started")
+        .removeClass("bg-green")
+        .addClass("bg-secondary")
   }
 
   selectCountryAndOpen(e) {

--- a/app/javascript/src/controllers/assessment_selection_controller.js
+++ b/app/javascript/src/controllers/assessment_selection_controller.js
@@ -26,13 +26,21 @@ export default class extends Controller {
     return this.selectedCountryTarget.value !== "-- Select One --"
   }
 
-  //validateForm() {
-  //return this.selectedCountryTarget.value !== "-- Select One --"
-  //}
+  validateAssessment() {
+    return (
+      this.assessmentTypesTarget.selectedOptions[0].value !== "-- Select One --"
+    )
+  }
+
+  validateAndEnableNext(e) {
+    $("#btn-next").prop('disabled', !(this.validateCountry() && this.validateAssessment()))
+  }
 
   selectCountry(e) {
     const countryName = this.selectedCountryTarget.value
-    const assessmentTypes = this.selectables[countryName]
+    const assessmentTypes = [
+      { type: "-- Select One --", text: "-- Select One --" }
+    ].concat(this.selectables[countryName])
     while (this.assessmentTypesTarget.firstChild)
       this.assessmentTypesTarget.removeChild(
         this.assessmentTypesTarget.firstChild
@@ -47,14 +55,7 @@ export default class extends Controller {
     if (this.hasSelectedCountryModalTarget)
       this.selectedCountryModalTarget.value = countryName
 
-    if (this.validateCountry())
-      $("#btn-get-started")
-        .removeClass("bg-secondary")
-        .addClass("bg-green")
-    else
-      $("#btn-get-started")
-        .removeClass("bg-green")
-        .addClass("bg-secondary")
+    $("#btn-get-started").prop("disabled", !this.validateCountry())
   }
 
   selectCountryAndOpen(e) {

--- a/app/views/landing/show.html.erb
+++ b/app/views/landing/show.html.erb
@@ -29,9 +29,10 @@
             %>
             <div class="input-group-append">
               <%= button_tag "Get Started",
+                id: "btn-get-started",
                 type: :button,
-                data: { action: "assessment-selection#openModal" },
-                class: "btn text-white bg-green" %>
+                data: { action: "assessment-selection#openModalValidated" },
+                class: "btn text-white bg-secondary" %>
             </div>
           </div>
         <% end %>

--- a/app/views/landing/show.html.erb
+++ b/app/views/landing/show.html.erb
@@ -32,7 +32,7 @@
                 id: "btn-get-started",
                 type: :button,
                 data: { action: "assessment-selection#openModalValidated" },
-                class: "btn text-white bg-secondary" %>
+                class: "btn text-white bg-green", disabled: true %>
             </div>
           </div>
         <% end %>

--- a/app/views/landing/show.html.erb
+++ b/app/views/landing/show.html.erb
@@ -25,14 +25,17 @@
               options_from_collection_for_select(@countries, 'name', 'name'),
               class: "custom-select",
               data: { target: "assessment-selection.selectedCountry",
-                      action: "assessment-selection#selectCountry" }
+                      action: "assessment-selection#selectCountry
+                               assessment-selection#validateAndEnableGetStarted"
+                    }
             %>
             <div class="input-group-append">
               <%= button_tag "Get Started",
-                id: "btn-get-started",
                 type: :button,
-                data: { action: "assessment-selection#openModalValidated" },
-                class: "btn text-white bg-green", disabled: true %>
+                data: { target: "assessment-selection.getStartedButton",
+                        action: "assessment-selection#openModalValidated" },
+                class: "btn text-white bg-green",
+                disabled: true %>
             </div>
           </div>
         <% end %>

--- a/app/views/shared/_assessment_selection_modal.html.erb
+++ b/app/views/shared/_assessment_selection_modal.html.erb
@@ -50,7 +50,12 @@
                       action: "assessment-selection#validateAndEnableNext" }
             %>
           </div>
-        <%= button_tag "Next", id: 'btn-next', type: :submit, class: "btn btn-primary w-100", disabled: true %> <% end %>
+          <%= button_tag "Next",
+              type: :submit,
+              class: "btn btn-primary w-100",
+              disabled: true,
+              data: { target: "assessment-selection.submitForm" } %>
+      <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_assessment_selection_modal.html.erb
+++ b/app/views/shared/_assessment_selection_modal.html.erb
@@ -46,10 +46,11 @@
             <%= select_tag "assessment_type",
               options_from_collection_for_select([], 'assessment_type', 'assessment_type'),
               class: "custom-select",
-              data: { target: "assessment-selection.assessmentTypes" }
+              data: { target: "assessment-selection.assessmentTypes",
+                      action: "assessment-selection#validateAndEnableNext" }
             %>
           </div>
-        <%= button_tag "Next", type: :submit, class: "btn btn-primary w-100" %> <% end %>
+        <%= button_tag "Next", id: 'btn-next', type: :submit, class: "btn btn-primary w-100", disabled: true %> <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_joint_assessment_selection_modal.html.erb
+++ b/app/views/shared/_joint_assessment_selection_modal.html.erb
@@ -38,16 +38,23 @@
               options_from_collection_for_select(@countries, 'name', 'name'),
               class: "custom-select",
               data: { target: "assessment-selection.selectedCountry",
-                      action: "assessment-selection#selectCountry" }
+                      action: "assessment-selection#selectCountry
+                               assessment-selection#validateAndEnableNext"
+                    }
             %>
           </div>
           <div class="input-group mb-2">
             <%= select_tag "assessment_type",
               options_from_collection_for_select([], 'assessment_type', 'assessment_type'),
               class: "custom-select",
-              data: { target: "assessment-selection.assessmentTypes" } %>
+              data: { target: "assessment-selection.assessmentTypes",
+                      action: "assessment-selection#validateAndEnableNext" } %>
           </div>
-          <%= button_tag "Next", type: :submit, class: "btn btn-primary w-100" %>
+          <%= button_tag "Next",
+            type: :submit,
+            class: "btn btn-primary w-100",
+            disabled: true,
+            data: { target: "assessment-selection.submitForm" } %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
This sets up placeholders for the assessment selections, instead of the old style of just automatically selecting the first country in the list. Additionally, it disables the "Next" and "Getting Started" buttons until the relevant fields have been selected.

In doing this, I gained a better understanding of StimulusJS, which is allowing some recomposition of how the various methods work in the stimulus controller.

# Screenshots
<img width="474" alt="Screen Shot 2019-09-04 at 3 16 26 PM" src="https://user-images.githubusercontent.com/8534888/64284369-74b1e300-cf27-11e9-8485-b1525ec8f403.png">
<img width="456" alt="Screen Shot 2019-09-04 at 3 16 31 PM" src="https://user-images.githubusercontent.com/8534888/64284370-75e31000-cf27-11e9-8dc2-658fb63646b3.png">
<img width="466" alt="Screen Shot 2019-09-04 at 3 16 41 PM" src="https://user-images.githubusercontent.com/8534888/64284387-82676880-cf27-11e9-9dc0-01a10d875cfa.png">
<img width="483" alt="Screen Shot 2019-09-04 at 3 16 55 PM" src="https://user-images.githubusercontent.com/8534888/64284389-84312c00-cf27-11e9-8f4d-d50b04ce760b.png">

# Stories

Resolves https://www.pivotaltracker.com/story/show/168155137