### PR TITLE
Give a bit more room to display target score in the print worksheet

### DIFF
--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -175,7 +175,7 @@ def populate_worksheet(
 
   worksheet.merge_cells idx, 0, idx, 1
   worksheet.merge_cells idx, 2, idx + 3, 7
-  worksheet.merge_cells idx + 6, 0, idx + 6, 2
+  worksheet.merge_cells idx + 6, 0, idx + 6, 3
   worksheet.merge_cells idx + 7, 0, idx + 9, 7
   worksheet.merge_cells idx + 11, 0, idx + 11, 2
   worksheet.merge_cells idx + 12, 0, idx + 26, 7


### PR DESCRIPTION
The target score was getting cut off at the end of the relevant cell in the worksheet. I went the route of just making the cell merge with one more cell to the right to provide more room without changing any other spacing.

# Screenshots
<img width="457" alt="Screen Shot 2019-09-04 at 4 10 09 PM" src="https://user-images.githubusercontent.com/8534888/64287742-83e85f00-cf2e-11e9-9810-08e3250ee93e.png">

# Stories
Resolves https://www.pivotaltracker.com/story/show/168155137