### PR TITLE
Refactor the activity map portion of the plan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'rack-attack'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'm'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    m (1.5.1)
+      method_source (>= 0.6.7)
+      rake (>= 0.9.2.2)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -229,6 +232,7 @@ DEPENDENCIES
   devise
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  m
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rack-attack

--- a/app/lib/activity_map.rb
+++ b/app/lib/activity_map.rb
@@ -29,4 +29,8 @@ class ActivityMap
   def benchmark_activities(benchmark_id)
     @m[benchmark_id.to_s]
   end
+
+  def to_json
+    @m.to_json
+  end
 end

--- a/app/lib/activity_map.rb
+++ b/app/lib/activity_map.rb
@@ -4,23 +4,23 @@ class ActivityMap
   end
 
   def benchmarks
-    @m.keys.map { |k| BenchmarkId.from_s k }.sort
+    @m.keys.map { |benchmark_id_str| BenchmarkId.from_s benchmark_id_str }.sort
   end
 
   def capacities
     benchmarks.map(&:capacity)
   end
 
-  def capacity_benchmarks(capacity)
-    capacity_ = Integer(capacity)
-    @m.keys.map { |k| BenchmarkId.from_s k }.filter do |k|
-      k.capacity == capacity_
-    end.sort
+  def capacity_benchmarks(capacity_id_str)
+    capacity_id = Integer(capacity_id_str)
+    @m.keys.map do |benchmark_id_str|
+      BenchmarkId.from_s benchmark_id_str
+    end.filter { |benchmark_id| benchmark_id.capacity == capacity_id }.sort
   end
 
-  def capacity_activities(capacity)
-    capacity_ = Integer(capacity)
-    capacity_benchmarks(capacity_).reduce({}) do |acc, benchmark_id|
+  def capacity_activities(capacity_id_str)
+    capacity_id = Integer(capacity_id_str)
+    capacity_benchmarks(capacity_id).reduce({}) do |acc, benchmark_id|
       acc[benchmark_id.to_s] = benchmark_activities(benchmark_id)
       acc
     end

--- a/app/lib/activity_map.rb
+++ b/app/lib/activity_map.rb
@@ -1,0 +1,20 @@
+class ActivityMap
+  def initialize(m)
+    #@m = m.transform_keys { |key| BenchmarkId.from_s key }
+    @m = m
+  end
+
+  def benchmarks
+    @m.keys.map { |k| BenchmarkId.from_s k }.sort
+  end
+
+  def indicators(capacity)
+    @m.keys.map { |k| BenchmarkId.from_s k }.filter do |k|
+      k.capacity_id == capacity
+    end.sort
+  end
+
+  def activities(benchmark_id)
+    @m[benchmark_id.to_s]
+  end
+end

--- a/app/lib/activity_map.rb
+++ b/app/lib/activity_map.rb
@@ -1,6 +1,5 @@
 class ActivityMap
   def initialize(m)
-    #@m = m.transform_keys { |key| BenchmarkId.from_s key }
     @m = m
   end
 
@@ -8,13 +7,26 @@ class ActivityMap
     @m.keys.map { |k| BenchmarkId.from_s k }.sort
   end
 
-  def indicators(capacity)
+  def capacities
+    benchmarks.map(&:capacity)
+  end
+
+  def capacity_benchmarks(capacity)
+    capacity_ = Integer(capacity)
     @m.keys.map { |k| BenchmarkId.from_s k }.filter do |k|
-      k.capacity_id == capacity
+      k.capacity == capacity_
     end.sort
   end
 
-  def activities(benchmark_id)
+  def capacity_activities(capacity)
+    capacity_ = Integer(capacity)
+    capacity_benchmarks(capacity_).reduce({}) do |acc, benchmark_id|
+      acc[benchmark_id.to_s] = benchmark_activities(benchmark_id)
+      acc
+    end
+  end
+
+  def benchmark_activities(benchmark_id)
     @m[benchmark_id.to_s]
   end
 end

--- a/app/lib/benchmark_id.rb
+++ b/app/lib/benchmark_id.rb
@@ -1,0 +1,31 @@
+class BenchmarkId
+  attr_reader :capacity_id, :indicator_id
+
+  def initialize(capacity_id, indicator_id)
+    @capacity_id = capacity_id
+    @indicator_id = indicator_id
+  end
+
+  def self.from_s(val)
+    c_str, i_str = val.split('.')
+    raise InvalidArgumentError if c_str.nil? || i_str.nil?
+
+    BenchmarkId.new (Integer c_str), (Integer i_str)
+  end
+
+  def to_s
+    "#{@capacity_id}.#{@indicator_id}"
+  end
+
+  def ==(other)
+    @capacity_id == other.capacity_id && @indicator_id == other.indicator_id
+  end
+
+  def <=>(other)
+    if @capacity_id == other.capacity_id
+      @indicator_id <=> other.indicator_id
+    else
+      @capacity_id <=> other.capacity_id
+    end
+  end
+end

--- a/app/lib/benchmark_id.rb
+++ b/app/lib/benchmark_id.rb
@@ -1,9 +1,16 @@
 class BenchmarkId
   attr_reader :capacity, :indicator
-
   def initialize(capacity, indicator)
     @capacity = capacity
     @indicator = indicator
+  end
+
+  def capacity_s
+    @capacity.to_s
+  end
+
+  def indicator_s
+    @indicator.to_s
   end
 
   def self.from_s(val)

--- a/app/lib/benchmark_id.rb
+++ b/app/lib/benchmark_id.rb
@@ -1,9 +1,9 @@
 class BenchmarkId
-  attr_reader :capacity_id, :indicator_id
+  attr_reader :capacity, :indicator
 
-  def initialize(capacity_id, indicator_id)
-    @capacity_id = capacity_id
-    @indicator_id = indicator_id
+  def initialize(capacity, indicator)
+    @capacity = capacity
+    @indicator = indicator
   end
 
   def self.from_s(val)
@@ -14,18 +14,18 @@ class BenchmarkId
   end
 
   def to_s
-    "#{@capacity_id}.#{@indicator_id}"
+    "#{@capacity}.#{@indicator}"
   end
 
   def ==(other)
-    @capacity_id == other.capacity_id && @indicator_id == other.indicator_id
+    @capacity == other.capacity && @indicator == other.indicator
   end
 
   def <=>(other)
-    if @capacity_id == other.capacity_id
-      @indicator_id <=> other.indicator_id
+    if @capacity == other.capacity
+      @indicator <=> other.indicator
     else
-      @capacity_id <=> other.capacity_id
+      @capacity <=> other.capacity
     end
   end
 end

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -11,6 +11,7 @@ class BenchmarksFixture
   end
 
   def capacity_text(capacity_id)
+    capacity_id = String(capacity_id)
     unless @fixture['benchmarks'][capacity_id]
       raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
     end
@@ -18,7 +19,9 @@ class BenchmarksFixture
   end
 
   def indicator_text(id)
-    capacity_id, indicator_id = id.split('.')
+    id_ = id.class == String ? (BenchmarkId.from_s id) : id
+    capacity_id = String(id_.capacity)
+    indicator_id = String(id_.indicator)
     unless @fixture['benchmarks'][capacity_id]
       raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
     end
@@ -29,7 +32,9 @@ class BenchmarksFixture
   end
 
   def objective_text(id)
-    capacity_id, indicator_id = id.split('.')
+    id_ = id.class == String ? (BenchmarkId.from_s id) : id
+    capacity_id = String(id_.capacity)
+    indicator_id = String(id_.indicator)
     unless @fixture['benchmarks'][capacity_id]
       raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
     end
@@ -40,7 +45,9 @@ class BenchmarksFixture
   end
 
   def goal_activities(id, score, goal)
-    capacity_id, indicator_id = id.split('.')
+    id_ = id.class == String ? (BenchmarkId.from_s id) : id
+    capacity_id = String(id_.capacity)
+    indicator_id = String(id_.indicator)
     unless @fixture['benchmarks'][capacity_id]
       raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
     end
@@ -71,7 +78,9 @@ class BenchmarksFixture
   end
 
   def level_activities(id, level)
-    capacity_id, indicator_id = id.split('.')
+    id_ = id.class == String ? (BenchmarkId.from_s id) : id
+    capacity_id = String(id_.capacity)
+    indicator_id = String(id_.indicator)
     unless @fixture['benchmarks'][capacity_id]
       raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
     end
@@ -91,7 +100,9 @@ class BenchmarksFixture
   end
 
   def activity_texts(id)
-    capacity_id, indicator_id = id.split('.')
+    id_ = id.class == String ? (BenchmarkId.from_s id) : id
+    capacity_id = String(id_.capacity)
+    indicator_id = String(id_.indicator)
     @fixture.dig(
       'benchmarks',
       capacity_id,

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -11,48 +11,53 @@ class BenchmarksFixture
   end
 
   def capacity_text(capacity_id)
-    capacity_id = String(capacity_id)
-    unless @fixture['benchmarks'][capacity_id]
-      raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
+    capacity_id_str = String(capacity_id)
+    unless @fixture['benchmarks'][capacity_id_str]
+      raise (ArgumentError.new "Invalid capacity: #{capacity_id_str}")
     end
-    @fixture['benchmarks'][capacity_id]['name']
+    @fixture['benchmarks'][capacity_id_str]['name']
   end
 
-  def indicator_text(id)
-    id_ = id.class == String ? (BenchmarkId.from_s id) : id
-    capacity_id = String(id_.capacity)
-    indicator_id = String(id_.indicator)
-    unless @fixture['benchmarks'][capacity_id]
-      raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
+  def indicator_text(benchmark_id)
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]
+      raise (ArgumentError.new "Invalid capacity: #{benchmark_id.capacity_s}")
     end
-    unless @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]
-      raise (ArgumentError.new "Invalid indicator: #{indicator_id}")
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+           benchmark_id.indicator_s
+         ]
+      raise (ArgumentError.new "Invalid indicator: #{benchmark_id.indicator_s}")
     end
-    @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]['indicator']
+    @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+      benchmark_id.indicator_s
+    ][
+      'indicator'
+    ]
   end
 
-  def objective_text(id)
-    id_ = id.class == String ? (BenchmarkId.from_s id) : id
-    capacity_id = String(id_.capacity)
-    indicator_id = String(id_.indicator)
-    unless @fixture['benchmarks'][capacity_id]
-      raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
+  def objective_text(benchmark_id)
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]
+      raise (ArgumentError.new "Invalid capacity: #{benchmark_id.capacity_s}")
     end
-    unless @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]
-      raise (ArgumentError.new "Invalid indicator: #{indicator_id}")
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+           benchmark_id.indicator_s
+         ]
+      raise (ArgumentError.new "Invalid indicator: #{benchmark_id.indicator_s}")
     end
-    @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]['objective']
+    @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+      benchmark_id.indicator_s
+    ][
+      'objective'
+    ]
   end
 
-  def goal_activities(id, score, goal)
-    id_ = id.class == String ? (BenchmarkId.from_s id) : id
-    capacity_id = String(id_.capacity)
-    indicator_id = String(id_.indicator)
-    unless @fixture['benchmarks'][capacity_id]
-      raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
+  def goal_activities(benchmark_id, score, goal)
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]
+      raise (ArgumentError.new "Invalid capacity: #{benchmark_id.capacity_s}")
     end
-    unless @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]
-      raise (ArgumentError.new "Invalid indicator: #{indicator_id}")
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+           benchmark_id.indicator_s
+         ]
+      raise (ArgumentError.new "Invalid indicator: #{benchmark_id.indicator_s}")
     end
 
     unless goal.value.between?(2, 5)
@@ -65,8 +70,10 @@ class BenchmarksFixture
 
     return(
       (score.value + 1..goal.value).reduce([]) do |acc, level|
-        acc.concat @fixture['benchmarks'][capacity_id]['indicators'][
-                     indicator_id
+        acc.concat @fixture['benchmarks'][benchmark_id.capacity_s][
+                     'indicators'
+                   ][
+                     benchmark_id.indicator_s
                    ][
                      'activities'
                    ][
@@ -77,21 +84,22 @@ class BenchmarksFixture
     )
   end
 
-  def level_activities(id, level)
-    id_ = id.class == String ? (BenchmarkId.from_s id) : id
-    capacity_id = String(id_.capacity)
-    indicator_id = String(id_.indicator)
-    unless @fixture['benchmarks'][capacity_id]
-      raise (ArgumentError.new "Invalid capacity: #{capacity_id}")
+  def level_activities(benchmark_id, level)
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]
+      raise (ArgumentError.new "Invalid capacity: #{benchmark_id.capacity_s}")
     end
-    unless @fixture['benchmarks'][capacity_id]['indicators'][indicator_id]
-      raise (ArgumentError.new "Invalid indicator: #{indicator_id}")
+    unless @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+           benchmark_id.indicator_s
+         ]
+      raise (ArgumentError.new "Invalid indicator: #{benchmark_id.indicator_s}")
     end
     unless level.value.between?(2, 5)
       raise RangeError.new 'level is not between 2 and 5'
     end
     return(
-      @fixture['benchmarks'][capacity_id]['indicators'][indicator_id][
+      @fixture['benchmarks'][benchmark_id.capacity_s]['indicators'][
+        benchmark_id.indicator_s
+      ][
         'activities'
       ][
         level.value.to_s
@@ -99,15 +107,12 @@ class BenchmarksFixture
     )
   end
 
-  def activity_texts(id)
-    id_ = id.class == String ? (BenchmarkId.from_s id) : id
-    capacity_id = String(id_.capacity)
-    indicator_id = String(id_.indicator)
+  def activity_texts(benchmark_id)
     @fixture.dig(
       'benchmarks',
-      capacity_id,
+      benchmark_id.capacity_s,
       'indicators',
-      indicator_id,
+      benchmark_id.indicator_s,
       'activities'
     )
       .values

--- a/app/lib/cost_sheet.rb
+++ b/app/lib/cost_sheet.rb
@@ -33,16 +33,17 @@ class CostSheet
 end
 
 def populate_contents(benchmarks, worksheet, idx, indicators)
-  indicators.keys.sort.each do |indicator_key|
-    activities = indicators.fetch(indicator_key)
+  indicators.keys.sort.each do |key|
+    benchmark_id = BenchmarkId.from_s key
+    activities = indicators.fetch(benchmark_id.to_s)
 
     if activities.length > 0
       SpreadsheetCell.new worksheet,
                           idx,
                           0,
                           text:
-                            "#{indicator_key}: #{
-                              benchmarks.indicator_text indicator_key
+                            "#{benchmark_id.to_s}: #{
+                              benchmarks.indicator_text benchmark_id
                             }"
 
       worksheet.merge_cells idx, 0, idx + activities.length - 1, 0
@@ -50,7 +51,7 @@ def populate_contents(benchmarks, worksheet, idx, indicators)
       SpreadsheetCell.new worksheet,
                           idx,
                           1,
-                          text: "#{benchmarks.objective_text indicator_key}"
+                          text: "#{benchmarks.objective_text benchmark_id}"
 
       worksheet.merge_cells idx, 1, idx + activities.length - 1, 1
     end

--- a/app/lib/cost_sheet.rb
+++ b/app/lib/cost_sheet.rb
@@ -27,11 +27,7 @@ class CostSheet
       populate_contents benchmarks,
                         worksheet,
                         idx,
-                        (
-                          @plan.activity_map.filter { |k, _|
-                            k.starts_with? "#{capacity[:id]}."
-                          }
-                        )
+                        (@plan.activity_map.capacity_activities capacity[:id])
     end
   end
 end

--- a/app/lib/goal_form.rb
+++ b/app/lib/goal_form.rb
@@ -47,8 +47,10 @@ class GoalForm
 
     benchmark_activities =
       benchmark_goals.each.reduce({}) do |acc, (key, pairing)|
+        benchmark_id = BenchmarkId.from_s(key)
         pairing.score = Score.new 1 if pairing.score.value == 0
-        acc[key] = benchmarks.goal_activities key, pairing.score, pairing.goal
+        acc[key] =
+          benchmarks.goal_activities benchmark_id, pairing.score, pairing.goal
         acc
       end
 

--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -26,18 +26,19 @@ class Worksheet
 
       idx = 0
 
-      (@plan.activity_map.filter { |k, _| k.starts_with? "#{capacity[:id]}." })
-        .keys
-        .each do |indicator_id|
-        @plan.activity_map[indicator_id].each do |activity|
+      (@plan.activity_map.capacity_benchmarks capacity[:id])
+        .each do |benchmark_id|
+        (@plan.activity_map.benchmark_activities benchmark_id)
+          .each do |activity|
+          goal = @plan.goals ? @plan.goals[benchmark_id.to_s] : {}
           idx =
             populate_worksheet worksheet,
                                idx,
                                assessment_structures[@plan.assessment_type][
                                  'label'
                                ],
-                               @plan.goals ? @plan.goals[indicator_id] : {},
-                               (benchmarks.objective_text indicator_id),
+                               goal,
+                               (benchmarks.objective_text benchmark_id),
                                activity
         end
       end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,3 +1,7 @@
 class Plan < ApplicationRecord
   belongs_to :user, optional: true
+
+  def activity_map
+    ActivityMap.new self[:activity_map]
+  end
 end

--- a/app/views/plans/_benchmark_activities.html.erb
+++ b/app/views/plans/_benchmark_activities.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="benchmark" data-target="benchmark.self" class="benchmark-container pb-3">
   <div class="row bg-light-gray p-1 header">
     <div class="col-11">
-      <b>Benchmark <%= benchmark_id %>:</b> <%=
+      <b>Benchmark <%= benchmark_id.to_s %>:</b> <%=
       benchmarks.indicator_text(benchmark_id) %>
     </div>
     <div class="col-1 d-flex justify-content-end" data-action="mouseleave->benchmark#reset">

--- a/app/views/plans/_benchmark_activities.html.erb
+++ b/app/views/plans/_benchmark_activities.html.erb
@@ -25,7 +25,7 @@
     </div>
   </div>
 
-  <%= content_tag :div, id: "activity_container_#{benchmark_id.parameterize}" do %>
+  <%= content_tag :div, id: "activity_container_#{benchmark_id.to_s.parameterize}" do %>
     <% activities.each do |activity| %>
       <%= render "activity", benchmark_id: benchmark_id, activity: activity %>
     <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -5,15 +5,15 @@
     <div class="row m-4">
       <div class="col">
         <% @plan.activity_map.capacities.each_with_index do | capacity_id, i | %>
-        <% capacity_name = @benchmarks.capacity_text(capacity_id) %>
+          <% capacity_name = @benchmarks.capacity_text(capacity_id) %>
           <div class="capacity-container">
             <h2 id="<%= capacity_name.parameterize %>"><%= i + 1 %>. <%= capacity_name %></h2>
             <% @plan.activity_map.capacity_benchmarks(capacity_id).each do |benchmark_id | %>
-            <!-- -->
+              <!-- -->
               <% activities = @plan.activity_map.benchmark_activities(benchmark_id) %>
               <%= render 'benchmark_activities', benchmark_id: benchmark_id,
                 activities: activities, benchmarks: @benchmarks %>
-            <!-- -->
+              <!-- -->
             <% end %>
           </div>
         <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -4,11 +4,13 @@
     <%= render "plan_form" %>
     <div class="row m-4">
       <div class="col">
-        <% @plan.activity_map.group_by { |b_id, activities| @benchmarks.capacity_text(b_id.split('.')[0]) }.each_with_index do |(capacity_name, activity_map), i| %>
-          <div class="capacity-container pb-4">
+        <% @plan.activity_map.capacities.each_with_index do | capacity_id, i | %>
+        <% capacity_name = @benchmarks.capacity_text(capacity_id) %>
+          <div class="capacity-container">
             <h2 id="<%= capacity_name.parameterize %>"><%= i + 1 %>. <%= capacity_name %></h2>
-            <% activity_map.each do |benchmark_id, activities| %>
+            <% @plan.activity_map.capacity_benchmarks(capacity_id).each do |benchmark_id | %>
             <!-- -->
+              <% activities = @plan.activity_map.benchmark_activities(benchmark_id) %>
               <%= render 'benchmark_activities', benchmark_id: benchmark_id,
                 activities: activities, benchmarks: @benchmarks %>
             <!-- -->

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -1,9 +1,9 @@
-require "minitest/autorun"
+require 'minitest/autorun'
 
 def create_draft_plan_stub
-  plan = Plan.create(name: "test plan", activity_map: [])
+  plan = Plan.create(name: 'test plan', activity_map: {})
   GoalForm.stub :create_draft_plan!, plan do
-    post goals_url, params: {goal_form: { assessment_type: "jee1"}}
+    post goals_url, params: { goal_form: { assessment_type: 'jee1' } }
     yield plan.id
   end
 end
@@ -11,27 +11,27 @@ end
 class PlansControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "plan#show redirects logged out user without session[:plan_id]" do
+  test 'plan#show redirects logged out user without session[:plan_id]' do
     get plan_path(1)
     assert_response :redirect
   end
 
-  test "redirects logged out user with mismatched session[:plan_id]" do
+  test 'redirects logged out user with mismatched session[:plan_id]' do
     create_draft_plan_stub do |plan_id|
-      get plan_path("another plan")
+      get plan_path('another plan')
       assert_response :redirect
     end
   end
 
-  test "logged out user can access a plan matching session[:plan_id]" do
+  test 'logged out user can access a plan matching session[:plan_id]' do
     create_draft_plan_stub do |plan_id|
       get plan_path(plan_id)
       assert_response :ok
     end
   end
 
-  test "logged in user can see their plan" do
-    plan = Plan.create(name: "a plan", activity_map: [])
+  test 'logged in user can see their plan' do
+    plan = Plan.create(name: 'a plan', activity_map: {})
     user = User.new(email: 'test@example.com')
     user.plans << plan
     sign_in user
@@ -40,44 +40,47 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "logged in user can't see someone else's plan" do
-    plan = Plan.create(name: "a plan", activity_map: [])
+    plan = Plan.create(name: 'a plan', activity_map: {})
     user = User.new(email: 'test@example.com')
     sign_in user
     get plan_path(plan.id)
     assert_response :redirect
   end
 
-  test "logged in user can update their plan" do
-    plan = Plan.create(name: "a draft plan", activity_map: [])
+  test 'logged in user can update their plan' do
+    plan = Plan.create(name: 'a draft plan', activity_map: {})
     user = User.new(email: 'test@example.com')
     user.plans << plan
     sign_in user
-    put plan_path(plan.id), params: { plan: {name: "the plan", activity_map: "[]"}}
-    assert_equal Plan.find_by_name("the plan").id, plan.id
+    put plan_path(plan.id),
+        params: { plan: { name: 'the plan', activity_map: '{}' } }
+    assert_equal Plan.find_by_name('the plan').id, plan.id
   end
 
   test "logged in user can't update someone else's plan" do
-    plan = Plan.create(name: "a draft plan", activity_map: [])
+    plan = Plan.create(name: 'a draft plan', activity_map: {})
     user = User.new(email: 'test@example.com')
     sign_in user
-    put plan_path(plan.id), params: { plan: {name: "the plan", activity_map: "[]"}}
+    put plan_path(plan.id),
+        params: { plan: { name: 'the plan', activity_map: '{}' } }
     assert_redirected_to root_path
-    assert_equal Plan.where(name: "the plan").count, 0
+    assert_equal Plan.where(name: 'the plan').count, 0
   end
 
   test "logged out user can't update a plan with id != session[:plan_id]" do
     create_draft_plan_stub do |plan_id|
-      put plan_path("another plan"), params: { plan: { name: "different" }}
+      put plan_path('another plan'), params: { plan: { name: 'different' } }
       assert_redirected_to root_path
     end
   end
 
-  test "logged out user can update a plan with id == session[:plan_id]" do
+  test 'logged out user can update a plan with id == session[:plan_id]' do
     create_draft_plan_stub do |plan_id|
-      put plan_path(plan_id), params: { plan: { name: "different", activity_map: "[]" }}
+      put plan_path(plan_id),
+          params: { plan: { name: 'different', activity_map: '{}' } }
       follow_redirect!
       assert_redirected_to new_user_session_path
-      assert_equal Plan.find_by_name("different").id, plan_id
+      assert_equal Plan.find_by_name('different').id, plan_id
     end
   end
 
@@ -86,25 +89,27 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test "logged in user sees a list of their plans" do
-    user = User.create!(email: 'test@example.com', password: "123455", role: "Donor")
-    plan1 = Plan.create!(name: "owned plan", activity_map: [])
+  test 'logged in user sees a list of their plans' do
+    user =
+      User.create!(email: 'test@example.com', password: '123455', role: 'Donor')
+    plan1 = Plan.create!(name: 'owned plan', activity_map: {})
     user.plans << plan1
-    Plan.create!(name: "orphan", activity_map: [])
+    Plan.create!(name: 'orphan', activity_map: {})
 
     sign_in user
     get plans_path
     assert_response :ok
-    assert_select ".plan-entry", 1
+    assert_select '.plan-entry', 1
 
     user.plans.first.destroy
     get plans_path
-    assert_select ".plan-entry", 0
+    assert_select '.plan-entry', 0
   end
 
-  test "user deletes their plan" do
-    user = User.create!(email: 'test@example.com', password: "123455", role: "Donor")
-    plan = Plan.create!(name: "owned plan", activity_map: [])
+  test 'user deletes their plan' do
+    user =
+      User.create!(email: 'test@example.com', password: '123455', role: 'Donor')
+    plan = Plan.create!(name: 'owned plan', activity_map: {})
     user.plans << plan
 
     sign_in user
@@ -113,8 +118,9 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "user deletes someone else's plan" do
-    user = User.create!(email: 'test@example.com', password: "123455", role: "Donor")
-    plan = Plan.create!(name: "a plan", activity_map: [])
+    user =
+      User.create!(email: 'test@example.com', password: '123455', role: 'Donor')
+    plan = Plan.create!(name: 'a plan', activity_map: {})
 
     sign_in user
     delete plan_path(plan.id)

--- a/test/lib/benchmark_id_test.rb
+++ b/test/lib/benchmark_id_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class BenchmarkIdTest < ActiveSupport::TestCase
   test 'verify that a benchmark id can be created from string' do
     id1 = BenchmarkId.from_s '1.15'
-    assert_equal 1, id1.capacity_id
-    assert_equal 15, id1.indicator_id
+    assert_equal 1, id1.capacity
+    assert_equal 15, id1.indicator
     assert_equal '1.15', id1.to_s
 
     id2 = BenchmarkId.from_s '10.01'
-    assert_equal 10, id2.capacity_id
-    assert_equal 1, id2.indicator_id
+    assert_equal 10, id2.capacity
+    assert_equal 1, id2.indicator
     assert_equal '10.1', id2.to_s
   end
 

--- a/test/lib/benchmark_id_test.rb
+++ b/test/lib/benchmark_id_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class BenchmarkIdTest < ActiveSupport::TestCase
+  test 'verify that a benchmark id can be created from string' do
+    id1 = BenchmarkId.from_s '1.15'
+    assert_equal 1, id1.capacity_id
+    assert_equal 15, id1.indicator_id
+    assert_equal '1.15', id1.to_s
+
+    id2 = BenchmarkId.from_s '10.01'
+    assert_equal 10, id2.capacity_id
+    assert_equal 1, id2.indicator_id
+    assert_equal '10.1', id2.to_s
+  end
+
+  test 'verify that benchmark ids are put in benchmark order' do
+    id_list = [
+      (BenchmarkId.from_s '2.5'),
+      (BenchmarkId.from_s '1.15'),
+      (BenchmarkId.from_s '11.10'),
+      (BenchmarkId.from_s '11.1')
+    ]
+    sorted_list = [
+      (BenchmarkId.from_s '1.15'),
+      (BenchmarkId.from_s '2.5'),
+      (BenchmarkId.from_s '11.1'),
+      (BenchmarkId.from_s '11.10')
+    ]
+
+    res = id_list.sort
+
+    assert_equal (BenchmarkId.from_s '2.5'), id_list[0]
+    assert_equal sorted_list, res
+  end
+end

--- a/test/lib/benchmarks_fixture_test.rb
+++ b/test/lib/benchmarks_fixture_test.rb
@@ -4,7 +4,8 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
   test 'reports activities for the requested level' do
     benchmarks = BenchmarksFixture.new
 
-    activities = benchmarks.level_activities '1.1', (Score.new 2)
+    activities =
+      benchmarks.level_activities (BenchmarkId.from_s '1.1'), (Score.new 2)
     assert_equal activities.length, 6
     assert_equal activities[0]['text'],
                  'Identify and convene key stakeholders related to the review, formulation and implementation of legislation and policies.'
@@ -13,7 +14,12 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
   test 'calculates activities for a score/goal range' do
     benchmarks = BenchmarksFixture.new
 
-    activities = benchmarks.goal_activities('1.1', (Score.new 2), (Score.new 4))
+    activities =
+      benchmarks.goal_activities(
+        (BenchmarkId.from_s '1.1'),
+        (Score.new 2),
+        (Score.new 4)
+      )
     assert_equal activities.length, 8
     assert_equal activities[0]['text'],
                  'Conduct an orientation with relevant stakeholders regarding adjustment in the legislation, laws, regulations, policy and administrative requirements.'
@@ -24,25 +30,35 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
   test 'raises an exception if a parameter is out of range' do
     benchmarks = BenchmarksFixture.new
     assert_raises(RangeError) do
-      benchmarks.level_activities '1.1', (Score.new 0)
+      benchmarks.level_activities (BenchmarkId.from_s '1.1'), (Score.new 0)
     end
     assert_raises(RangeError) do
-      benchmarks.level_activities '1.1', (Score.new 6)
+      benchmarks.level_activities (BenchmarkId.from_s '1.1'), (Score.new 6)
     end
     assert_raises(RangeError) do
-      benchmarks.goal_activities '1.1', (Score.new 6), (Score.new 5)
+      benchmarks.goal_activities (BenchmarkId.from_s '1.1'),
+                                 (Score.new 6),
+                                 (Score.new 5)
     end
     assert_raises(RangeError) do
-      benchmarks.goal_activities '1.1', (Score.new 0), (Score.new 5)
+      benchmarks.goal_activities (BenchmarkId.from_s '1.1'),
+                                 (Score.new 0),
+                                 (Score.new 5)
     end
     assert_raises(RangeError) do
-      benchmarks.goal_activities '1.1', (Score.new 1), (Score.new 0)
+      benchmarks.goal_activities (BenchmarkId.from_s '1.1'),
+                                 (Score.new 1),
+                                 (Score.new 0)
     end
     assert_raises(RangeError) do
-      benchmarks.goal_activities '1.1', (Score.new 1), (Score.new 6)
+      benchmarks.goal_activities (BenchmarkId.from_s '1.1'),
+                                 (Score.new 1),
+                                 (Score.new 6)
     end
     assert_raises(ArgumentError) do
-      benchmarks.goal_activities '1.1', (Score.new 5), (Score.new 3)
+      benchmarks.goal_activities (BenchmarkId.from_s '1.1'),
+                                 (Score.new 5),
+                                 (Score.new 3)
     end
   end
 
@@ -55,18 +71,26 @@ class BenchmarksFixtureTest < ActiveSupport::TestCase
 
   test 'returns the correct indicator text for a given id' do
     benchmarks = BenchmarksFixture.new
-    assert_raises(ArgumentError) { benchmarks.indicator_text '19.1' }
-    assert_raises(ArgumentError) { benchmarks.indicator_text '17.2' }
+    assert_raises(ArgumentError) do
+      benchmarks.indicator_text (BenchmarkId.from_s '19.1')
+    end
+    assert_raises(ArgumentError) do
+      benchmarks.indicator_text (BenchmarkId.from_s '17.2')
+    end
     assert_equal 'Mechanisms are in place for surveillance, alert and response to chemical events or emergencies',
-                 (benchmarks.indicator_text '17.1')
+                 (benchmarks.indicator_text (BenchmarkId.from_s '17.1'))
   end
 
   test 'returns the correct objective text for a given id' do
     benchmarks = BenchmarksFixture.new
-    assert_raises(ArgumentError) { benchmarks.objective_text '19.1' }
-    assert_raises(ArgumentError) { benchmarks.objective_text '17.2' }
+    assert_raises(ArgumentError) do
+      benchmarks.objective_text (BenchmarkId.from_s '19.1')
+    end
+    assert_raises(ArgumentError) do
+      benchmarks.objective_text (BenchmarkId.from_s '17.2')
+    end
     assert_equal 'Establish policies, legislation, plans and capacities for surveillance, alert and response to chemical events or emergencies',
-                 (benchmarks.objective_text '17.1')
+                 (benchmarks.objective_text (BenchmarkId.from_s '17.1'))
   end
 
   test 'returns the text of a type code' do

--- a/test/lib/goal_form_test.rb
+++ b/test/lib/goal_form_test.rb
@@ -26,7 +26,7 @@ class GoalFormTest < ActiveSupport::TestCase
                  {
                    '1.1' =>
                      @benchmarks.goal_activities(
-                       '1.1',
+                       (BenchmarkId.from_s '1.1'),
                        (Score.new 1),
                        (Score.new 3)
                      )
@@ -76,7 +76,7 @@ class GoalFormTest < ActiveSupport::TestCase
                  {
                    '1.1' =>
                      @benchmarks.goal_activities(
-                       '1.1',
+                       (BenchmarkId.from_s '1.1'),
                        (Score.new 1),
                        (Score.new 5)
                      )
@@ -106,7 +106,7 @@ class GoalFormTest < ActiveSupport::TestCase
                  {
                    '1.1' =>
                      @benchmarks.goal_activities(
-                       '1.1',
+                       (BenchmarkId.from_s '1.1'),
                        (Score.new 1),
                        (Score.new 4)
                      )
@@ -134,7 +134,7 @@ class GoalFormTest < ActiveSupport::TestCase
                  {
                    '1.1' =>
                      @benchmarks.goal_activities(
-                       '1.1',
+                       (BenchmarkId.from_s '1.1'),
                        (Score.new 1),
                        (Score.new 2)
                      )
@@ -162,7 +162,7 @@ class GoalFormTest < ActiveSupport::TestCase
                  {
                    '1.1' =>
                      @benchmarks.goal_activities(
-                       '1.1',
+                       (BenchmarkId.from_s '1.1'),
                        (Score.new 1),
                        (Score.new 2)
                      )

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -61,17 +61,27 @@ class PlanTest < ActiveSupport::TestCase
                  plan.activity_map.benchmarks
   end
 
-  test 'that I can get a list of indicators given a capacity' do
+  test 'that I can get a list of benchmark ids within a given capacity' do
     plan = demo_plan
-    assert_equal [(BenchmarkId.from_s '3.3')], (plan.activity_map.indicators 3)
+    assert_equal [(BenchmarkId.from_s '3.3')],
+                 (plan.activity_map.capacity_benchmarks 3)
     assert_equal [(BenchmarkId.from_s '2.1'), (BenchmarkId.from_s '2.2')],
-                 (plan.activity_map.indicators 2)
+                 (plan.activity_map.capacity_benchmarks 2)
+  end
+
+  test 'that I can get an indexed map of activities from a capacity id' do
+    plan = demo_plan
+    assert_equal %w[2.1 2.2], (plan.activity_map.capacity_activities 2).keys
   end
 
   test 'that I can get a list of capacities from a BenchmarkId' do
     plan = demo_plan
     assert_equal 3,
-                 (plan.activity_map.activities (BenchmarkId.from_s '2.1'))
+                 (
+                   plan.activity_map.benchmark_activities (
+                                                            BenchmarkId.from_s '2.1'
+                                                          )
+                 )
                    .length
   end
 end

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+def demo_plan
+  Plan.create! name: 'US Draft Plan',
+               country: 'United States',
+               assessment_type: 'jee2',
+               activity_map: {
+                 "2.1": [
+                   {
+                     'text' =>
+                       'Designate or establish an NFP in line with the IHR requirements.',
+                     'type_code_1' => 4,
+                     'type_code_2' => nil,
+                     'type_code_3' => nil
+                   },
+                   {
+                     'text' =>
+                       'Establish terms of reference outlining the role and responsibilities of IHR NFPs in fulfilling relevant obligations of the IHR.',
+                     'type_code_1' => 10,
+                     'type_code_2' => nil,
+                     'type_code_3' => nil
+                   },
+                   {
+                     'text' =>
+                       "Maintain and regularly update a contact directory including all the members of NFP and capacitate NFPs for 24 hours a day, seven\n days a week (24/7) accessibility.",
+                     'type_code_1' => 10,
+                     'type_code_2' => 3,
+                     'type_code_3' => nil
+                   }
+                 ],
+                 "2.2": [
+                   {
+                     'text' =>
+                       'Create/update the national action plan for improving health security and IHR capacity based on IHR monitoring and evaluation results.',
+                     'type_code_1' => nil,
+                     'type_code_2' => nil,
+                     'type_code_3' => nil
+                   }
+                 ],
+                 "3.3": [
+                   {
+                     'text' =>
+                       'Use the national IPC assessment tool (IPCAT2) to identify precise areas still requiring action and update the plan of action.',
+                     'type_code_1' => 2,
+                     'type_code_2' => nil,
+                     'type_code_3' => nil
+                   }
+                 ]
+               },
+               user_id: nil
+end
+
+class PlanTest < ActiveSupport::TestCase
+  test 'that I can get a sorted list of benchmark ids in the plan' do
+    plan = demo_plan
+    assert_equal [
+                   (BenchmarkId.from_s '2.1'),
+                   (BenchmarkId.from_s '2.2'),
+                   (BenchmarkId.from_s '3.3')
+                 ],
+                 plan.activity_map.benchmarks
+  end
+
+  test 'that I can get a list of indicators given a capacity' do
+    plan = demo_plan
+    assert_equal [(BenchmarkId.from_s '3.3')], (plan.activity_map.indicators 3)
+    assert_equal [(BenchmarkId.from_s '2.1'), (BenchmarkId.from_s '2.2')],
+                 (plan.activity_map.indicators 2)
+  end
+
+  test 'that I can get a list of capacities from a BenchmarkId' do
+    plan = demo_plan
+    assert_equal 3,
+                 (plan.activity_map.activities (BenchmarkId.from_s '2.1'))
+                   .length
+  end
+end


### PR DESCRIPTION
This is an effort to reduce some of the complicated filters and grouping functions that sometimes make some of the code difficult to understand.

Accomplishing this requires the introduction of BenchmarkId, which gives structured meaning to benchmark ids (for instance, 1.1 < 1.10 < 10.1, etc...).

Once this is present, it becomes easier to encapsulate the idea of a BenchmarkId belonging to a capacity, and thus being able to extract its peers in both the BenchmarkFixture structure and the ActivityMap structure.

One side effect, which provides extra discipline but also extra verbosity, is some explicit data type conversions and checks.

# Stories

Resolves https://www.pivotaltracker.com/story/show/168194847
