### PR TITLE
Fix the add activity form in the draft plan

### DIFF
--- a/app/views/plans/_activity_form.html.erb
+++ b/app/views/plans/_activity_form.html.erb
@@ -1,5 +1,5 @@
 <div class="row activity-form">
   <div class="col">
-    <%= text_field_tag :new_activity, nil, class: "w-100", placeholder: "+ Add Activity", data: { target: "plan.newActivity", action: "keypress->plan#addNewActivity", "benchmark-id": benchmark_id, "activities": activities.to_json } %>
+    <%= text_field_tag :new_activity, nil, class: "w-100", placeholder: "+ Add Activity", data: { target: "plan.newActivity", action: "keypress->plan#addNewActivity", "benchmark-id": benchmark_id.to_s, "activities": activities.to_json } %>
   </div>
 </div>


### PR DESCRIPTION
BenchmarkId objects were getting serialized in JSON form, but the code is actually designed to work with string versions of a benchmark id. So, I'm solving this by simply telling the benchmark id to become a string.

# Stories

Resolves https://www.pivotaltracker.com/story/show/168351060