### PR TITLE
Iterate over the benchmarks when displaying the draft plan

### DIFF
--- a/app/lib/activity_map.rb
+++ b/app/lib/activity_map.rb
@@ -13,7 +13,7 @@ class ActivityMap
   # Return a list of Technical Capacity ids for those benchmarks that are
   # present in the draft plan.
   def capacities
-    benchmarks.map(&:capacity)
+    benchmarks.map(&:capacity).uniq
   end
 
   # Return a list of BenchmarkIds corresponding to the specified Technical
@@ -37,7 +37,7 @@ class ActivityMap
 
   # Return a list of all activities in the specified BenchmarkId.
   def benchmark_activities(benchmark_id)
-    @m[benchmark_id.to_s]
+    @m[benchmark_id.to_s] ? @m[benchmark_id.to_s] : []
   end
 
   def to_json

--- a/app/lib/benchmarks_fixture.rb
+++ b/app/lib/benchmarks_fixture.rb
@@ -12,7 +12,7 @@ class BenchmarksFixture
   # Get a sorted list of all of the capacity ids.
   def capacities
     @fixture['benchmarks'].keys.map(&:to_i).sort.map do |k|
-      ({ id: k.to_s, name: @fixture['benchmarks'][k.to_s]['name'] })
+      ({ id: k, name: @fixture['benchmarks'][k.to_s]['name'] })
     end
   end
 
@@ -25,6 +25,22 @@ class BenchmarksFixture
       raise (ArgumentError.new "Invalid capacity: #{capacity_id_str}")
     end
     @fixture['benchmarks'][capacity_id_str]['name']
+  end
+
+  def capacity_benchmarks(capacity_id)
+    capacity_id_str = String(capacity_id)
+    unless @fixture['benchmarks'][capacity_id_str]
+      raise (ArgumentError.new "Invalid capacity: #{capacity_id_str}")
+    end
+    indicators = @fixture['benchmarks'][capacity_id_str]['indicators']
+    indicators.keys.map(&:to_i).sort.map do |k|
+      k_str = String(k)
+      {
+        id: (BenchmarkId.new capacity_id, k),
+        indicator: indicators[k_str]['indicator'],
+        objective: indicators[k_str]['objective']
+      }
+    end
   end
 
   # Get the indicator text for a benchmark. The parameter must be a

--- a/app/views/plans/_benchmark_activities.html.erb
+++ b/app/views/plans/_benchmark_activities.html.erb
@@ -25,8 +25,8 @@
     </div>
   </div>
 
-  <% goal = @plan.goals ? Score.new(@plan.goals[benchmark_id.to_s]["value"]) : nil %>
-  <% score = @plan.scores ? Score.new(@plan.scores[benchmark_id.to_s]["value"]) : nil %>
+  <% goal = @plan.goals && @plan.goals[benchmark_id.to_s] ? Score.new(@plan.goals[benchmark_id.to_s]["value"]) : nil %>
+  <% score = @plan.scores && @plan.scores[benchmark_id.to_s] ? Score.new(@plan.scores[benchmark_id.to_s]["value"]) : nil %>
 
   <%= content_tag :div, id: "activity_container_#{benchmark_id.to_s.parameterize}" do %>
     <% if (goal == score) && activities.length.zero? %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -4,14 +4,13 @@
     <%= render "plan_form" %>
     <div class="row m-4">
       <div class="col">
-        <% @plan.activity_map.capacities.each_with_index do | capacity_id, i | %>
-          <% capacity_name = @benchmarks.capacity_text(capacity_id) %>
+        <% @benchmarks.capacities.each do |capacity| %>
           <div class="capacity-container">
-            <h2 id="<%= capacity_name.parameterize %>"><%= i + 1 %>. <%= capacity_name %></h2>
-            <% @plan.activity_map.capacity_benchmarks(capacity_id).each do |benchmark_id | %>
+            <h2 id="<%= capacity[:name].parameterize %>"><%= capacity[:id] %>. <%= capacity[:name] %></h2>
+            <% (@benchmarks.capacity_benchmarks capacity[:id]).each do |benchmark| %>
               <!-- -->
-              <% activities = @plan.activity_map.benchmark_activities(benchmark_id) %>
-              <%= render 'benchmark_activities', benchmark_id: benchmark_id,
+              <% activities = @plan.activity_map.benchmark_activities(benchmark[:id]) %>
+              <%= render 'benchmark_activities', benchmark_id: benchmark[:id],
                 activities: activities, benchmarks: @benchmarks %>
               <!-- -->
             <% end %>

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -37,6 +37,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     get plan_path(plan.id)
     assert_response :ok
+    assert_select '.capacity-container', 18
   end
 
   test "logged in user can't see someone else's plan" do
@@ -47,18 +48,27 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "plan/show.html.erb wires up plan controller correctly" do
-    plan = Plan.create(name: 'a plan', activity_map: {"1.1" => [{"text": "Activity 1"}, {"text": "Activity 2"}]})
+  test 'plan/show.html.erb wires up plan controller correctly' do
+    plan =
+      Plan.create(
+        name: 'a plan',
+        activity_map: {
+          '1.1' => [{ "text": 'Activity 1' }, { "text": 'Activity 2' }]
+        }
+      )
     user = User.new(email: 'test@example.com')
     user.plans << plan
     sign_in user
     get plan_path(plan.id)
     assert_select '.plan-container[data-controller="plan"]', 1
     assert_select 'form[data-target="plan.form"]', 1
-    assert_select 'input[data-target="plan.name"][data-action="change->plan#validateName"]', 1
+    assert_select 'input[data-target="plan.name"][data-action="change->plan#validateName"]',
+                  1
     assert_select 'input[data-target="plan.activityMap"]', 1
-    assert_select 'input[data-target="plan.newActivity"][data-action="keypress->plan#addNewActivity"][data-benchmark-id="1.1"]', 1
-    assert_select 'button[data-action="plan#deleteActivity"][data-benchmark-id="1.1"]', 2
+    assert_select 'input[data-target="plan.newActivity"][data-action="keypress->plan#addNewActivity"][data-benchmark-id="1.1"]',
+                  1
+    assert_select 'button[data-action="plan#deleteActivity"][data-benchmark-id="1.1"]',
+                  2
   end
 
   test 'logged in user can update their plan' do

--- a/test/lib/benchmarks_fixture_test.rb
+++ b/test/lib/benchmarks_fixture_test.rb
@@ -1,6 +1,39 @@
 require 'test_helper'
 
 class BenchmarksFixtureTest < ActiveSupport::TestCase
+  test 'retrieves a complete list of capacities' do
+    benchmarks = BenchmarksFixture.new
+
+    assert_equal [
+                   1,
+                   2,
+                   3,
+                   4,
+                   5,
+                   6,
+                   7,
+                   8,
+                   9,
+                   10,
+                   11,
+                   12,
+                   13,
+                   14,
+                   15,
+                   16,
+                   17,
+                   18
+                 ],
+                 (benchmarks.capacities.map { |v| v[:id] })
+  end
+
+  test 'retrieves all of the benchmarks within a capacity' do
+    benchmarks = BenchmarksFixture.new
+
+    assert_equal %w[7.1 7.2 7.3 7.4],
+                 ((benchmarks.capacity_benchmarks 7).map { |v| v[:id].to_s })
+  end
+
   test 'reports activities for the requested level' do
     benchmarks = BenchmarksFixture.new
 

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -51,6 +51,11 @@ def demo_plan
 end
 
 class PlanTest < ActiveSupport::TestCase
+  test 'that I get a sorted list of capacities' do
+    plan = demo_plan
+    assert_equal [2, 3], plan.activity_map.capacities
+  end
+
   test 'that I can get a sorted list of benchmark ids in the plan' do
     plan = demo_plan
     assert_equal [


### PR DESCRIPTION
We have been iterating over the activity map. Aside from an undetected capacity duplication error, this also meant that we would never even display a section for a benchmark that never existed in the activity map.

Iterating over the entire draft plan requires that the code handles places where we query the activity map for benchmarks that are absent.

We have no automated tests for this as we don't actually check the HTML that results from any of the controllers.

I would actually like to pair through this review so we can discuss some of the details to ensure that they make sense.