### PR TITLE
Savanni/draft plan header overlap

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -47,12 +47,22 @@
 
 .capacity-container {
   h2 {
+    left: 0px;
+    top: 0px;
     font-family: Karla;
     font-style: normal;
     font-weight: bold;
     font-size: 24px;
     line-height: 24px;
     text-transform: uppercase;
+
+    /* http://darktef.github.io/posts/2017-03-offset-html-anchors-for-fixed-header-with-css */
+    &::before {
+      content:"";
+      display:block;
+      margin-top:-155px;
+      height:155px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -47,22 +47,12 @@
 
 .capacity-container {
   h2 {
-    left: 0px;
-    top: 0px;
     font-family: Karla;
     font-style: normal;
     font-weight: bold;
     font-size: 24px;
     line-height: 24px;
     text-transform: uppercase;
-
-    /* http://darktef.github.io/posts/2017-03-offset-html-anchors-for-fixed-header-with-css */
-    &::before {
-      content:"";
-      display:block;
-      margin-top:-155px;
-      height:155px;
-    }
   }
 }
 

--- a/app/javascript/src/controllers/scroll_controller.js
+++ b/app/javascript/src/controllers/scroll_controller.js
@@ -1,10 +1,20 @@
 import { Controller } from "stimulus"
 
 /* This controller allows a dropdown menu to trigger a scroll to any target in
- * the page, and will update the URL to reflect that. */
+ * the page, offset by 160 pixels to take into account the sticky header. */
 export default class extends Controller {
   scroll(e) {
-    const { value } = e.currentTarget
-    window.location.hash = value
+    var elem = document.getElementById(e.currentTarget.value)
+    window.scrollTo(0, findAbsolutePosition(elem) - 160)
   }
+}
+
+/* Find the absolute page position of an element. Since the offsetTop for an
+ * element is with respect to its parent, this works by travelling up the
+ * document hierarchy and getting the offset of each element until it finds the
+ * root node. */
+function findAbsolutePosition(elem) {
+  return elem.offsetParent
+    ? elem.offsetTop + findAbsolutePosition(elem.offsetParent)
+    : elem.offsetTop
 }


### PR DESCRIPTION
This fixes the problem where navigating to a section from the draft plan dropdown menu doesn't take into account that there is a large sticky header.