### PR TITLE
plan_controller.currentActivities must very that the benchmarkId exists

### DIFF
--- a/app/javascript/src/controllers/plan_controller.js
+++ b/app/javascript/src/controllers/plan_controller.js
@@ -156,7 +156,9 @@ export default class extends Controller {
   /* Get the text of all of the current activities for a benchmark in the
    * activity map. */
   currentActivities(benchmarkId) {
-    return this.activityMap[benchmarkId].map(a => a.text)
+    return this.activityMap[benchmarkId]
+      ? this.activityMap[benchmarkId].map(a => a.text)
+      : []
   }
 
   /* This provides the list of all possible activities in for a benchmark.


### PR DESCRIPTION
The draft plan controller was failing to connect because in iterating over all of the benchmarks in the benchmark fixture, it was running across places where the benchmark doesn't exist in the draft plan. We now check for that and return an empty list.

