### PR TITLE
[Scores Page] Changing capacity score didn't work

### DIFF
--- a/app/javascript/src/controllers/score_and_goal_controller.js
+++ b/app/javascript/src/controllers/score_and_goal_controller.js
@@ -1,0 +1,129 @@
+import { Controller } from "stimulus"
+import $ from "jquery"
+
+const SCORES = [0, 1, 2, 3, 4, 5]
+
+// TODO: update this comment
+/* This controller continuously validates all of the score entries in the
+ * assessment and goal setting page. It checks first that the score and goal
+ * are set to allowed values, and verifies that the score never exceeds the
+ * goal.
+ *
+ * We used DOM searches instead of stimulus targets to jump between scores and
+ * goals. There's no inherent reason we can't use stimulus targets instead. In
+ * the context of a validation event, we care about the event's target (score
+ * or goal input) and its corresponding pair input. Since the controller spans
+ * the entire form, it was simpler to find the pair directly with
+ * currentTarget's id and getElementById than traverse a list of goal or score
+ * targets. Another reasonable strategy would be to instantiate one controller
+ * per pair, and have scoreTarget and goalTarget, but this would require us to
+ * re-do the input fields interaction with the submit button.
+ *
+ * Targets:
+ *   submitButton -- the button to submit the form. This controller will enable
+ *   or disable the button based on form validity. The button should be of type
+ *   submit, but should also call the `submit` method on this controller. The
+ *   stimulus action will occur before the form submit, allowing this
+ *   controller to block the form submit if the form is invalid.
+ *
+ *   form -- the functional area of the form. There is one last validity check
+ *   before the form gets submitted.
+ *
+ */
+export default class extends Controller {
+  static targets = ["score", "goal"]
+
+  initialize() {
+    this.parentController = this.application.controllers.find(controller => {
+      return controller.context.identifier === "score";
+    });
+    this.parentController.childControllers.push(this)
+    this.isFullyValid = true
+  }
+
+  connect() {
+    $('[data-toggle="tooltip"]').tooltip({
+      trigger: "manual",
+      container: "#new_goal_form"
+    })
+    window.app = this.application
+  }
+
+  validatePair(e) {
+    const {currentTarget: currentField} = e
+
+    const isValidScore = this.isFieldValid(this.scoreTarget)
+    const isValidGoal = this.isFieldValid(this.goalTarget)
+    const isValidPair = this.isFieldPairValid(currentField)
+    console.log("GVT: isValidScore, isValidGoal, isValidPair", isValidScore, isValidGoal, isValidPair)
+
+
+    // hide all tooltips if any are invalid cuz state could be anything
+    if (!isValidScore || !isValidGoal || !isValidPair) {
+      $(this.scoreTarget).tooltip("hide")
+      $(this.goalTarget).tooltip("hide")
+      this.isFullyValid = false
+    }
+
+    if (!isValidScore && !isValidGoal) {
+      console.log("GVT: WHICH: !isValidScore && !isValidGoal")
+      $(currentField).tooltip("show")
+    } else if (!isValidScore) {
+      console.log("GVT: WHICH: invalid score, show tooltip", currentField, this.scoreTarget)
+      $(this.scoreTarget).tooltip("show")
+    } else if (!isValidGoal) {
+      console.log("GVT: WHICH: invalid goal, show tooltip", currentField, this.goalTarget)
+      $(this.goalTarget).tooltip("show")
+    } else if (isValidScore && isValidGoal && !isValidPair) {
+      console.log("GVT: WHICH: isValidScore && isValidGoal && !isValidPair")
+      $(currentField).tooltip("show")
+    } else { // all valid
+      console.log("GVT: WHICH: ELSE should not hit")
+      $(this.scoreTarget).tooltip("hide")
+      $(this.goalTarget).tooltip("hide")
+      this.isFullyValid = true
+    }
+
+    this.parentController.setFieldColor(currentField)
+    // update the parent form
+    this.parentController.updateFormStateFromChildren()
+  }
+
+  isFieldValid(field) {
+    field.setCustomValidity("")
+    let isValid = null
+    if (field.value.length === 0) {
+      field.setCustomValidity("invalid")
+      field.setAttribute("data-original-title", "The value cannot be empty")
+      isValid = false
+    } else if (!SCORES.includes(Number(field.value))) {
+      field.setCustomValidity("invalid")
+      field.setAttribute(
+          "data-original-title",
+          "The value must be within range"
+      )
+      isValid = false
+    } else {
+      isValid = true
+    }
+    field.parentElement.classList.add("was-validated")
+    return isValid
+  }
+
+  isFieldPairValid(currentField) {
+    if (Number(this.scoreTarget.value) > Number(this.goalTarget.value)) {
+      currentField.setCustomValidity("invalid")
+      currentField.setAttribute(
+          "data-original-title",
+          "The goal must be higher than the capacity score"
+      )
+      return false
+    }
+    return true
+  }
+
+  isValid() {
+    return this.isFullyValid
+  }
+
+}

--- a/app/javascript/src/controllers/score_controller.js
+++ b/app/javascript/src/controllers/score_controller.js
@@ -1,20 +1,8 @@
 import { Controller } from "stimulus"
 import $ from "jquery"
 
-/* This controller continuously validates all of the score entries in the
- * assessment and goal setting page. It checks first that the score and goal
- * are set to allowed values, and verifies that the score never exceeds the
- * goal.
- *
- * We used DOM searches instead of stimulus targets to jump between scores and
- * goals. There's no inherent reason we can't use stimulus targets instead. In
- * the context of a validation event, we care about the event's target (score
- * or goal input) and its corresponding pair input. Since the controller spans
- * the entire form, it was simpler to find the pair directly with
- * currentTarget's id and getElementById than traverse a list of goal or score
- * targets. Another reasonable strategy would be to instantiate one controller
- * per pair, and have scoreTarget and goalTarget, but this would require us to
- * re-do the input fields interaction with the submit button.
+/* This controller checks its child controllers to determine its form validity
+ * and enables or disables its submit button accordingly.
  *
  * Targets:
  *   submitButton -- the button to submit the form. This controller will enable

--- a/app/views/goals/_validated_field.html.erb
+++ b/app/views/goals/_validated_field.html.erb
@@ -1,11 +1,12 @@
+<% is_goal = field_name.match?("goal") %>
 <div class="form-group">
-  <%= f.number_field field_name, 
-    data: { action: "change->score#validate", 
-            goal: field_name.match?("goal"),
+  <%= f.number_field field_name,
+    data: { action: "change->score-and-goal#validatePair",
+            goal: is_goal,
+            target: is_goal ? "score-and-goal.goal": "score-and-goal.score",
             toggle: "tooltip",
             placement: "top",
-          }, 
-    class: "form-control w-70px color-score-#{@goals.send(field_name)}", 
+          },
+    class: "form-control w-70px color-score-#{@goals.send(field_name)}",
     required: true %>
 </div>
-

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -93,13 +93,13 @@
           <tbody>
             <% @technical_area_ids.each do |technical_area_id| %>
               <% technical_area = @assessments[@display_assessment_type]['technical_areas'][technical_area_id] %>
-              <tr class="technical-area-<%= technical_area_id %>">
+              <tr class="technical-area-<%= technical_area_id %>"
+                  data-controller="score-and-goal">
                 <% indicator = technical_area['indicators'][0] %>
                 <th
                   class="border-right"
                   scope="row"
                   rowspan="<%= technical_area['indicators'].count %>"
-                  data-controller="score-and-goal"
                 >
                   <%= @data_dictionary[technical_area_id] %>
                 </th>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -99,6 +99,7 @@
                   class="border-right"
                   scope="row"
                   rowspan="<%= technical_area['indicators'].count %>"
+                  data-controller="score-and-goal"
                 >
                   <%= @data_dictionary[technical_area_id] %>
                 </th>
@@ -113,7 +114,8 @@
               </tr>
 
               <% technical_area['indicators'].drop(1).each do |indicator| %>
-                <tr class="technical-area-<%= technical_area_id %>">
+                <tr class="technical-area-<%= technical_area_id %>"
+                    data-controller="score-and-goal">
                   <td class="border-right"><%= @data_dictionary[indicator] %></td>
                   <td>
                     <%= render "validated_field", field_name: indicator, f: f %>

--- a/test/controllers/goals_controller_test.rb
+++ b/test/controllers/goals_controller_test.rb
@@ -37,7 +37,7 @@ class GoalsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select 'form[data-controller="score"][data-action="submit->score#submit"][data-target="score.form"]', 1
     # there are a total of 96 score and goal fields for this assessment
-    assert_select 'input[data-action="change->score#validate"]', 96
+    assert_select 'input[data-action="change->score-and-goal#validatePair"]', 96
     assert_select 'input[type="submit"][data-target="score.submitButton"]', 1
   end
 

--- a/test/javascript/score_and_goal_controller.test.js
+++ b/test/javascript/score_and_goal_controller.test.js
@@ -1,0 +1,271 @@
+import { Application, Controller } from "stimulus"
+import ScoreController from "score_controller"
+import ScoreAndGoalController from "score_and_goal_controller"
+import $ from "jquery"
+// jest.mock("jquery")
+// $.mockImplementation(() => { tooltip: jest.fn() })
+// mocking it this way worked best, the 2 lines above resulted in JS errors when code called $(...).tooltip(...)
+$.fn.tooltip = jest.fn()
+
+describe("ScoreAndGoalController", () => {
+
+  describe("#initialize", () => {
+    let application
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="score">
+        <div data-controller="score-and-goal">
+          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-target="score.submitButton" />
+          </form>
+        </div>
+      </div>
+      `
+      application = Application.start()
+      application.register("score", ScoreController)
+      application.register("score-and-goal", ScoreAndGoalController)
+    })
+
+    it("sets parentController as expected", () => {
+      const scoreController = application.controllers[0]
+      const scoreAndGoalController = application.controllers[1]
+      expect(scoreAndGoalController.parentController).toBe(scoreController)
+    })
+
+    it("adds itself to its parentController's children", () => {
+      const scoreController = application.controllers[0]
+      const scoreAndGoalController = application.controllers[1]
+      expect(scoreController.childControllers).toContain(scoreAndGoalController)
+    })
+  })
+
+  describe("#isFieldValid", () => {
+    let application
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="score">
+        <div data-controller="score-and-goal">
+          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-target="score.submitButton" />
+          </form>
+        </div>
+      </div>
+      `
+      application = Application.start()
+      application.register("score", ScoreController)
+      application.register("score-and-goal", ScoreAndGoalController)
+    })
+
+    it("returns false for empty value", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      const field = document.getElementById("score1")
+      field.value = ""
+
+      const result = scoreAndGoalController.isFieldValid(field)
+      expect(result).toBe(false)
+      expect(field.getAttribute("data-original-title")).toBe("The value cannot be empty")
+      expect(field.parentElement.classList).toContain("was-validated")
+    })
+
+    it("returns false for an out-of-range value", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      const field = document.getElementById("score1")
+      field.value = "6"
+
+      const result = scoreAndGoalController.isFieldValid(field)
+      expect(result).toBe(false)
+      expect(field.getAttribute("data-original-title")).toBe("The value must be within range")
+      expect(field.parentElement.classList).toContain("was-validated")
+    })
+
+    it("returns true for a valid value", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      const field = document.getElementById("score1")
+      field.value = "3"
+
+      const result = scoreAndGoalController.isFieldValid(field)
+      expect(result).toBe(true)
+      expect(field.parentElement.classList).toContain("was-validated")
+    })
+  })
+
+  describe("#isFieldPairValid", () => {
+    let application
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="score">
+        <div data-controller="score-and-goal">
+          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-target="score.submitButton" />
+          </form>
+        </div>
+      </div>
+      `
+      application = Application.start()
+      application.register("score", ScoreController)
+      application.register("score-and-goal", ScoreAndGoalController)
+    })
+
+    it("returns false when", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      const scoreField = document.getElementById("score1")
+      const goalField  = document.getElementById("score1_goal")
+      scoreField.value = "3"
+      goalField.value  = "2"
+
+      const result = scoreAndGoalController.isFieldPairValid(goalField)
+      expect(result).toBe(false)
+      expect(goalField.getAttribute("data-original-title")).toBe("The goal must be higher than the capacity score")
+    })
+
+    it("returns false for an out-of-range value", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      const scoreField = document.getElementById("score1")
+      const goalField  = document.getElementById("score1_goal")
+      scoreField.value = "2"
+      goalField.value  = "3"
+
+      const result = scoreAndGoalController.isFieldValid(scoreField)
+      expect(result).toBe(true)
+    })
+  })
+
+  describe("#validatePair", () => {
+    let application
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="score">
+        <div data-controller="score-and-goal">
+          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" data-toggle="tooltip" placement="top" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  data-toggle="tooltip" placement="top" id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-target="score.submitButton" />
+          </form>
+        </div>
+      </div>
+      `
+      application = Application.start()
+      application.register("score", ScoreController)
+      application.register("score-and-goal", ScoreAndGoalController)
+    })
+
+    it("returns 1 when score and goal is invalid", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFieldValid = jest.fn().mockReturnValue(false)
+      const field = document.getElementById("score1")
+
+      const result = scoreAndGoalController.validatePair(null, field)
+      expect(result).toBe(1)
+    })
+
+    it("returns 2 when score is invalid", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFieldValid = jest.fn().
+        mockReturnValueOnce(false).
+        mockReturnValueOnce(true)
+      const field = document.getElementById("score1")
+
+      const result = scoreAndGoalController.validatePair(null, field)
+      expect(result).toBe(2)
+    })
+
+    it("returns 3 when goal is invalid", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFieldValid = jest.fn().
+        mockReturnValueOnce(true).
+        mockReturnValueOnce(false)
+      const field = document.getElementById("score1")
+
+      const result = scoreAndGoalController.validatePair(null, field)
+      expect(result).toBe(3)
+    })
+
+    it("returns 4 when score and goal are valid but the pair is invalid", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFieldValid = jest.fn().
+        mockReturnValueOnce(true).
+        mockReturnValueOnce(true)
+      scoreAndGoalController.isFieldPairValid = jest.fn().mockReturnValue(false)
+      const field = document.getElementById("score1")
+
+      const result = scoreAndGoalController.validatePair(null, field)
+      expect(result).toBe(4)
+    })
+
+    it("returns 5 when score and goal and pair all are valid", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFieldValid = jest.fn().
+        mockReturnValueOnce(true).
+        mockReturnValueOnce(true)
+      scoreAndGoalController.isFieldPairValid = jest.fn().mockReturnValue(true)
+      const field = document.getElementById("score1")
+
+      const result = scoreAndGoalController.validatePair(null, field)
+      expect(result).toBe(5)
+    })
+  })
+
+  describe("#isValid", () => {
+    let application
+    beforeEach(() => {
+      document.body.innerHTML = `
+      <div data-controller="score">
+        <div data-controller="score-and-goal">
+          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-target="score.submitButton" />
+          </form>
+        </div>
+      </div>
+      `
+      application = Application.start()
+      application.register("score", ScoreController)
+      application.register("score-and-goal", ScoreAndGoalController)
+    })
+
+    it("returns true when isFullyValid equals true", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFullyValid = true
+
+      expect(scoreAndGoalController.isValid()).toBe(true)
+    })
+
+    it("returns false when isFullyValid equals false", () => {
+      const scoreAndGoalController = application.controllers.find(controller => {
+        return controller.context.identifier === "score-and-goal";
+      });
+      scoreAndGoalController.isFullyValid = false
+
+      expect(scoreAndGoalController.isValid()).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
- split ScoreController into ScoreAndGoalController which gives more granular control over how the score/goal pairs are validated and tooltips containing validation messages are displayed
- connect the ScoreController and ScoreAndGoalController to have a parent/children relationship and be able to send method calls up and down to manage state
- validation and UI updated are performed by the ScoreAndGoalController on both score/goal input pair at the same time in order to show only one tooltip at a time per Stacy
- add test coverage for the new ScoreAndGoalController and update existing coverage
- had some difficulty with testing the `$.tooltip` method, had to come up with a workaround to have a return value for testing purposes
- modify two ERB templates to split into 2 Stimulus controllers instead of one with minimal changes
- update comments per these changes

Fixes #168934855