### PR TITLE
[Draft Plan] Show indicator number ahead of the activity copy #169573364

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -35,6 +35,33 @@
       }
     }
   }
+
+  .goal-value-circle {
+    margin-top: 0.5em;
+  }
+  .badge-rounded-circle {
+    height: 2.25em;
+    width: 2.25em;
+  }
+  .badge-rounded-circle span {
+    position: relative;
+    top: 0.4em;
+    color: white;
+  }
+
+  .color-value-0,
+  .color-value-1 {
+    background-color: color("red");
+  }
+  .color-value-2,
+  .color-value-3 {
+    background-color: color("yellow");
+  }
+  .color-value-4,
+  .color-value-5 {
+    background-color: color("green");
+  }
+
   .activity-form {
     padding: 0.5rem;
     padding-left: 0;

--- a/app/views/plans/_activity.html.erb
+++ b/app/views/plans/_activity.html.erb
@@ -1,10 +1,13 @@
 <div class="row activity p-2 type-code-<%= (@benchmarks.type_code_1s[activity["type_code_1"].to_s] || "unknown").parameterize %>">
-  <div class="col-1 goal-value-circle">
-    <span class="badge badge-pill badge-success badge-rounded-circle color-value-<%= goal.value %>">
-      <span><%= goal.value %></span>
-    </span>
-  </div>
-  <div class="col-10">
+  <%# goal = nil %>
+  <% if goal.present? %>
+    <div class="col-1 goal-value-circle">
+      <span class="badge badge-pill badge-success badge-rounded-circle color-value-<%= goal.value %>">
+        <span><%= goal.value %></span>
+      </span>
+    </div>
+  <% end %>
+  <div class="col-1<%= goal.present? ? 0: 1 %>">
     <%= activity["text"] %>
   </div>
   <div class="col-1">

--- a/app/views/plans/_activity.html.erb
+++ b/app/views/plans/_activity.html.erb
@@ -1,5 +1,10 @@
 <div class="row activity p-2 type-code-<%= (@benchmarks.type_code_1s[activity["type_code_1"].to_s] || "unknown").parameterize %>">
-  <div class="col-11">
+  <div class="col-1 goal-value-circle">
+    <span class="badge badge-pill badge-success badge-rounded-circle color-value-<%= goal.value %>">
+      <span><%= goal.value %></span>
+    </span>
+  </div>
+  <div class="col-10">
     <%= activity["text"] %>
   </div>
   <div class="col-1">

--- a/app/views/plans/_benchmark_activities.html.erb
+++ b/app/views/plans/_benchmark_activities.html.erb
@@ -37,7 +37,7 @@
       </div>
     <% end %>
     <% activities.each do |activity| %>
-      <%= render "activity", benchmark_id: benchmark_id, activity: activity %>
+      <%= render "activity", benchmark_id: benchmark_id, activity: activity, goal: goal %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
- add column in the activity partial for the goal value circle with badge style
- modify benchmark_activities partial to pass goal as a local
- add styles for the goal value to display as a circle and for spacing, used only on the plans page

Fixes # 169573364