### PR TITLE
Display count of total activities at top of page #169572912

### DIFF
--- a/app/views/plans/_activity.html.erb
+++ b/app/views/plans/_activity.html.erb
@@ -1,5 +1,4 @@
 <div class="row activity p-2 type-code-<%= (@benchmarks.type_code_1s[activity["type_code_1"].to_s] || "unknown").parameterize %>">
-  <%# goal = nil %>
   <% if goal.present? %>
     <div class="col-1 goal-value-circle">
       <span class="badge badge-pill badge-success badge-rounded-circle color-value-<%= goal.value %>">
@@ -8,6 +7,7 @@
     </div>
   <% end %>
   <div class="col-1<%= goal.present? ? 0: 1 %>">
+    <strong><%= benchmark_id %></strong>
     <%= activity["text"] %>
   </div>
   <div class="col-1">


### PR DESCRIPTION
- display benchmark_id in bold
- remove forgotten debugging statement