### PR TITLE
[Draft Plan] Show the goal value to the left of the action copy #169573338

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -109,3 +109,28 @@
     font-size: 58px;
   }
 }
+
+.activity-count-header {
+  font-family: "Pathway Gothic One", sans-serif;
+  .activity-count-circle {
+    width: 90px;
+    height: 90px;
+    background-color: #D86422;
+    border-radius: 45px;
+    &:hover {
+      opacity: 0.5;
+    }
+    span {
+      color: #F8F9FA;
+      font-size: 36px;
+      line-height: 41px;
+    }
+  }
+  p {
+    margin: 0;
+    text-transform: uppercase;
+    font-size: 24px;
+    line-height: 28px;
+    color: rgba(45, 45, 53, 0.5);
+  }
+}

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -7,4 +7,19 @@ class Plan < ApplicationRecord
   def activity_map
     ActivityMap.new self[:activity_map]
   end
+
+  def all_activities(benchmarks = BenchmarksFixture.new)
+    activities = []
+    return activities if self[:activity_map].blank?
+
+    benchmarks.capacities.map do |capacity|
+      benchmarks.capacity_benchmarks(capacity[:id]).map do |benchmark|
+        self.activity_map.benchmark_activities(benchmark[:id]).map do |key, val|
+          activities << key["text"]
+        end
+      end
+    end.flatten
+    activities
+  end
+
 end

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,6 +2,14 @@
 <div class="row">
   <div class="col plan-container" data-controller="plan">
     <%= render "plan_form" %>
+    <div class="activity-count-header row m-4 d-flex flex-row align-items-center">
+      <div class="activity-count-circle col-auto d-flex flex-column align-items-center justify-content-center">
+        <span><%= @plan.all_activities.size %></span>
+      </div>
+      <div class="col-auto">
+        <p>Total Activities</p>
+      </div>
+    </div>
     <div class="row m-4">
       <div class="col">
         <% @benchmarks.capacities.each do |capacity| %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require File.expand_path('./test/test_helper')
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -147,9 +147,10 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     user =
       User.create!(email: 'test@example.com', password: '123455', role: 'Donor')
     plan = Plan.create!(name: 'a plan', activity_map: {})
+    before_plan_count = Plan.count
 
     sign_in user
     delete plan_path(plan.id)
-    assert_equal 1, Plan.count
+    assert_equal before_plan_count, Plan.count
   end
 end

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -1,4 +1,4 @@
-require 'application_system_test_case'
+require File.expand_path('./test/application_system_test_case')
 require 'capybara/cuprite'
 require 'capybara/minitest/spec'
 
@@ -28,6 +28,8 @@ class AppsTest < ApplicationSystemTestCase
 
     assert_current_path(%r{plans\/\d+})
     assert_equal 'Armenia draft plan', find('#plan_name').value
+    assert page.has_content?('TOTAL ACTIVITIES')
+    assert_equal '103', find('.activity-count-circle span').text
 
     assert page.has_content?(
              'Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors.'


### PR DESCRIPTION
- add new method Plan#all_activities to collect all of the activities for a given plan
- modify show.html.erb to have structure for the total count of activities header/circle/etc
- add styles to plan.scss for the total count of activities header/circle/etc
- add test coverage for the model's new method
- add test coverage for the total count of activities header/circle is rendered to the page
- modify existing plans_controller_test to assert against the delta of plan count rather than an absolute value which fails during test iterations in dev
- modify existing tests to be able to run as part of `rake test` AND via `ruby <test file path>` to enable faster development