### PR TITLE
Bug fix for [Draft Plan] Move form element for plan name into navy blue bar replacing the filter dropdowns #169572703

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
     <div class="container-fluid">
       <div class="row">
-        <div class="col-12">
+        <div class="offset-1 col-10">
 
           <% if notice %>
             <div class="alert alert-primary">

--- a/app/views/plans/_plan_form.html.erb
+++ b/app/views/plans/_plan_form.html.erb
@@ -1,8 +1,8 @@
 <div class="row bg-dark-blue py-4 px-0 full-width stick-to-top text-white">
 
-    <div class="col-10 row px-0 justify-content-between align-items-center offset-1">
+    <div class="col-10 offset-1 row px-0 justify-content-between">
 
-      <div class="col-4 py-0" style="height: 60px;">
+      <div style="height: 60px;">
         <%= form_for @plan, class: "needs-validation", novalidate: true, data: { target: "plan.form" } do |f| %>
           <%= f.hidden_field :activity_map, value: @plan.activity_map.to_json, data: {
               target: "plan.activityMap"}, autocomplete: "off" %>
@@ -15,7 +15,7 @@
         <% end %>
       </div>
 
-      <div class="col-2" style="min-width: 140px;">
+      <div style="min-width: 140px;">
         <%= submit_tag "Save Plan", data: { target: "plan.submit", action: "plan#submit"}, class: "btn btn-orange w-100 align-self-center" %>
       </div>
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -6,10 +6,10 @@
     <!-- Plan Form: Edit Name, Save Plan -->
     <%= render "plan_form" %>
 
-    <div class="row justify-content-center">
+    <div class="row">
 
       <!-- Count of Total Activities -->
-      <div class="col-10 mt-5">
+      <div class="mt-5">
         <div class="row mx-0 activity-count-header align-items-center">
           <div class="activity-count-circle col-auto d-flex flex-column align-items-center justify-content-center">
             <span><%= @plan.all_activities.size %></span>
@@ -21,7 +21,7 @@
       </div>
 
       <!-- List of Activities -->
-      <div class="col-10 mt-5">
+      <div class="mt-5">
         <% @benchmarks.capacities.each do |capacity| %>
           <% if @plan.assessment_type == "from-capacities" %>
             <% if (@plan.activity_map.capacity_activities capacity[:id]).length > 0 %>


### PR DESCRIPTION
Fix a bug I introduced to other pages' layout from my earlier changes in this branch by re-placing an offset in application layout and the plan form, tweaking styles on plans/show page, and simplify styles where possible.