### PR TITLE
[Draft Plan] Add static bar chart to filter by Capacity Area #169573124

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -1,3 +1,5 @@
+@import "chartist/dist/scss/chartist.scss";
+
 .benchmark-container {
   margin-bottom: 50px;
   .header {
@@ -130,5 +132,34 @@
     font-size: 24px;
     line-height: 28px;
     color: rgba(45, 45, 53, 0.5);
+  }
+}
+
+.card.plan {
+  overflow: hidden;
+
+  ul.nav-tabs {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+}
+
+#bar-chart {
+  .ct-vertical {
+    stroke: #C3C9D8;
+    stroke-dasharray: 0;
+    stroke-width: 0.7;
+  }
+
+  .ct-horizontal {
+    stroke: none;
+  }
+
+  .ct-series-a .ct-bar {
+    stroke: #0D4A59;
+    stroke-width: 24;
+  }
+
+  .ct-label {
+    font-size: .5em;
   }
 }

--- a/app/javascript/src/controllers/plan_controller.js
+++ b/app/javascript/src/controllers/plan_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
   static targets = ["activityMap", "newActivity", "submit", "form"]
 
   connect() {
+    this.initBarChart()
     if (document.referrer.match("goals")) {
       $("#draft-plan-review-modal").modal("show")
     }
@@ -176,5 +177,27 @@ export default class extends Controller {
    */
   get activityMap() {
     return JSON.parse(this.activityMapTarget.value)
+  }
+
+  initBarChart() {
+    let data = {
+      labels: JSON.parse(this.data.get("chartLabels")),
+      series: [
+        JSON.parse(this.data.get("chartSeries"))
+      ]
+    };
+    let options = {
+      high: 40,
+      low: 0,
+      width: this.data.get("chartWidth"),
+      height: this.data.get("chartHeight"),
+      axisY: {
+        // show only even-numbered X-axis labels
+        labelInterpolationFnc: function (value, index) {
+          return index % 2 === 0 ? value : null;
+        }
+      },
+    };
+    new Chartist.Bar(this.data.get("chartSelector"), data, options);
   }
 }

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -22,4 +22,15 @@ class Plan < ApplicationRecord
     activities
   end
 
+  def count_activities_by_capacity(benchmarks = BenchmarksFixture.new)
+    counts = []
+    benchmarks.capacities.each_with_index do |capacity, i|
+      counts[i] = 0 if counts[i].blank?
+      benchmarks.capacity_benchmarks(capacity[:id]).map do |benchmark|
+        counts[i] += self.activity_map.benchmark_activities(benchmark[:id]).size
+      end
+    end
+    counts
+  end
+
 end

--- a/app/views/plans/_plan_form.html.erb
+++ b/app/views/plans/_plan_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row bg-dark-blue py-4 px-0 full-width stick-to-top text-white">
 
-    <div class="col-10 offset-1 row px-0 justify-content-between">
+    <div class="col-10 offset-1 row justify-content-between">
 
       <div style="height: 60px;">
         <%= form_for @plan, class: "needs-validation", novalidate: true, data: { target: "plan.form" } do |f| %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,15 +1,24 @@
+<%
+  chart_labels = %w(P1 P2 P3 P4 P5 P6 P7 D1 D2 D3 D4 R1 R2 R3 R4 R5 POE CE RE)
+%>
+
 <%= render "plan_review_modal" %>
 
 <div class="row">
-  <div class="col plan-container" data-controller="plan">
+  <div class="col plan-container" data-controller="plan"
+       data-plan-chart-selector="#bar-chart"
+       data-plan-chart-labels="<%= chart_labels.to_json %>"
+       data-plan-chart-series="<%= @plan.count_activities_by_capacity %>"
+       data-plan-chart-width="730"
+       data-plan-chart-height="240"
+  >
 
-    <!-- Plan Form: Edit Name, Save Plan -->
+    <!-- Plan Form: Edit Name, Save Plan (its a DIV.row) -->
     <%= render "plan_form" %>
 
+    <!-- Count of Total Activities -->
     <div class="row">
-
-      <!-- Count of Total Activities -->
-      <div class="mt-5">
+      <div class="col mt-5">
         <div class="row mx-0 activity-count-header align-items-center">
           <div class="activity-count-circle col-auto d-flex flex-column align-items-center justify-content-center">
             <span><%= @plan.all_activities.size %></span>
@@ -19,9 +28,39 @@
           </div>
         </div>
       </div>
+    </div>
 
-      <!-- List of Activities -->
-      <div class="mt-5">
+    <!-- Row for Bar Chart and Nudge -->
+    <div class="row">
+      <div class="col mt-5">
+        <!-- Card for Bar Chart and Nudge -->
+        <div class="card plan">
+          <ul class="nav nav-tabs pt-3">
+            <li class="nav-item px-2">
+              <a class="nav-link active" href="#">Technical Area</a>
+            </li>
+          </ul>
+          <div class="row">
+            <div class="col-auto d-flex flex-column justify-content-center align-items-center bar-chart-col">
+
+              <!-- Actual Bar Chart -->
+              <h6 class="my-3">Actions per technical area</h6>
+              <div id="bar-chart" class="ct-chart-bar"></div>
+
+            </div>
+
+            <div class="col">
+              <!-- RIGHT COL: nudge goes here -->
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- List of Activities -->
+    <div class="row">
+      <div class="col mt-5">
         <% @benchmarks.capacities.each do |capacity| %>
           <% if @plan.assessment_type == "from-capacities" %>
             <% if (@plan.activity_map.capacity_activities capacity[:id]).length > 0 %>
@@ -32,7 +71,6 @@
           <% end %>
         <% end %>
       </div>
-
     </div>
 
   </div>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -7,7 +7,8 @@ environment.plugins.append(
     $: "jquery",
     jQuery: "jquery",
     "window.jQuery": "jquery",
-    Popper: ["popper.js", "default"]
+    Popper: ["popper.js", "default"],
+    Chartist: ["chartist"]
   })
 )
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "jquery-ujs": "^1.2.2",
     "popper.js": "^1.15.0",
     "stimulus": "^1.1.1",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "chartist": "^0.11.4"
   },
   "prettier": {
     "semi": false

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -134,4 +134,13 @@ describe Plan do
     end
   end
 
+  describe "#count_activities_by_capacity" do
+
+    it "returns the expected array of integers" do
+      @plan.count_activities_by_capacity.must_equal(
+          [0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    end
+
+  end
+
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,6 +2311,11 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chartist@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/chartist/-/chartist-0.11.4.tgz#e96e1c573d8b67478920a3a6ae52359d9fc8d8b7"
+  integrity sha512-H4AimxaUD738/u9Mq8t27J4lh6STsLi4BQHt65nOtpLk3xyrBPaLiLMrHw7/WV9CmsjGA02WihjuL5qpSagLYw==
+
 chokidar@^2.0.2, chokidar@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"


### PR DESCRIPTION
- add rb method Plan#count_activities_by_capacity to collect count of activities grouped by top-level Capacity Area
- add Chartist to package.json for use with webpacker
- add Chartist to webpack configuration in environment.js file
- add js method PlanController#initBarChart to init Chartist Bar Chart, uses Stimulus Data Maps API
- add chartist scss import for bring in its styles
- add styles for .card.plan and #bar-chart used only on the Draft Plans page
- add lots of other markup and style modifications to build per design specs

Fixes #169573124