### PR TITLE
[Draft Plan] When user clicks on a bar of the Capacity Area chart the list is filtered #169573486

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -154,9 +154,13 @@
     stroke: none;
   }
 
-  .ct-series-a .ct-bar {
+  .ct-series .ct-bar {
     stroke: #0D4A59;
     stroke-width: 24;
+
+    &:hover {
+      stroke: #4D838F;
+    }
   }
 
   .ct-label {

--- a/app/javascript/src/controllers/plan_controller.js
+++ b/app/javascript/src/controllers/plan_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "stimulus"
+import Chartist from "chartist"
 import $ from "jquery"
 
 import renderActivity from "../renderActivity"
@@ -180,8 +181,9 @@ export default class extends Controller {
   }
 
   initBarChart() {
+    this.chartLabels = JSON.parse(this.data.get("chartLabels"))
     let data = {
-      labels: JSON.parse(this.data.get("chartLabels")),
+      labels: this.chartLabels,
       series: [
         JSON.parse(this.data.get("chartSeries"))
       ]
@@ -198,6 +200,20 @@ export default class extends Controller {
         }
       },
     };
-    new Chartist.Bar(this.data.get("chartSelector"), data, options);
+    this.chart = new Chartist.Bar(this.data.get("chartSelector"), data, options);
+    this.chart.on('created', this.setBarChartEventListeners.bind(this))
+  }
+
+  // TODO: no test coverage for this yet because mocking jQuery ($) in the way.
+  setBarChartEventListeners() {
+    $("line.ct-bar").each((i, el) => {
+      let $el = $(el)
+      if (this.chartLabels[i]) {
+        $($el).on('click', () => {
+          $('.capacity-container').hide()
+          $('#capacity-' + this.chartLabels[i]).show()
+        })
+      }
+    })
   }
 }

--- a/app/views/plans/_capacity.html.erb
+++ b/app/views/plans/_capacity.html.erb
@@ -1,4 +1,4 @@
-<div class="capacity-container">
+<div class="capacity-container" id="capacity-<%= chart_label %>">
   <h2 id="<%= capacity[:name].parameterize %>"><%= capacity[:id] %>. <%= capacity[:name] %></h2>
   <% (@benchmarks.capacity_benchmarks capacity[:id]).each do |benchmark| %>
     <!-- -->

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -61,13 +61,13 @@
     <!-- List of Activities -->
     <div class="row">
       <div class="col mt-5">
-        <% @benchmarks.capacities.each do |capacity| %>
+        <% @benchmarks.capacities.each_with_index do |capacity, i| %>
           <% if @plan.assessment_type == "from-capacities" %>
             <% if (@plan.activity_map.capacity_activities capacity[:id]).length > 0 %>
-              <%= render 'capacity', capacity: capacity %>
+              <%= render 'capacity', capacity: capacity, labels: chart_labels %>
             <% end %>
           <% else %>
-            <%= render 'capacity', capacity: capacity %>
+            <%= render 'capacity', capacity: capacity, chart_label: chart_labels[i] %>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
- add JS PlanController#setBarChartEventListeners to set a click event handler for each bar in the chart
- add to each capacity container an ID that is connected to bar chart segments, e.g. "capacity-p7"
- modify plans/show template to pass in the relevant chart label, e.g., "p7"
- add style for hover over a bar in the chart to change color