### PR TITLE
[Draft Plan] Show tooltip on hover of a bar on the TA chart #169573506

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -1,5 +1,69 @@
 @import "chartist/dist/scss/chartist.scss";
 
+.plan-entry {
+  a {
+    color: color("black");
+    &:hover {
+      color: color("primary");
+    }
+  }
+}
+
+.tips-header {
+  font-family: Pathway Gothic One;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 48px;
+  line-height: 55px;
+  margin-bottom: 40px;
+}
+
+.plan-index-header {
+  margin-top: 50px;
+  h1 {
+    font-family: Pathway Gothic One;
+    text-transform: uppercase;
+    font-size: 58px;
+  }
+}
+
+.activity-count-header {
+  font-family: "Pathway Gothic One", sans-serif;
+  .activity-count-circle {
+    width: 90px;
+    height: 90px;
+    background-color: #D86422;
+    border-radius: 45px;
+    cursor: pointer;
+    &:hover {
+      opacity: 0.5;
+    }
+    span {
+      color: #F8F9FA;
+      font-size: 36px;
+      line-height: 41px;
+    }
+  }
+  p {
+    margin: 0;
+    text-transform: uppercase;
+    font-size: 24px;
+    line-height: 28px;
+    color: rgba(45, 45, 53, 0.5);
+  }
+}
+
+.capacity-container {
+  h2 {
+    font-family: Karla;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 24px;
+    line-height: 24px;
+    text-transform: uppercase;
+  }
+}
+
 .benchmark-container {
   margin-bottom: 50px;
   .header {
@@ -72,70 +136,6 @@
   }
 }
 
-.capacity-container {
-  h2 {
-    font-family: Karla;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 24px;
-    line-height: 24px;
-    text-transform: uppercase;
-  }
-}
-
-.plan-entry {
-  a {
-    color: color("black");
-    &:hover {
-      color: color("primary");
-    }
-  }
-}
-
-.tips-header {
-  font-family: Pathway Gothic One;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 48px;
-  line-height: 55px;
-  margin-bottom: 40px;
-}
-
-.plan-index-header {
-  margin-top: 50px;
-  h1 {
-    font-family: Pathway Gothic One;
-    text-transform: uppercase;
-    font-size: 58px;
-  }
-}
-
-.activity-count-header {
-  font-family: "Pathway Gothic One", sans-serif;
-  .activity-count-circle {
-    width: 90px;
-    height: 90px;
-    background-color: #D86422;
-    border-radius: 45px;
-    cursor: pointer;
-    &:hover {
-      opacity: 0.5;
-    }
-    span {
-      color: #F8F9FA;
-      font-size: 36px;
-      line-height: 41px;
-    }
-  }
-  p {
-    margin: 0;
-    text-transform: uppercase;
-    font-size: 24px;
-    line-height: 28px;
-    color: rgba(45, 45, 53, 0.5);
-  }
-}
-
 .card.plan {
   overflow: hidden;
 
@@ -144,7 +144,7 @@
   }
 }
 
-#bar-chart {
+#bar-chart-for-ta {
   .ct-vertical {
     stroke: #C3C9D8;
     stroke-dasharray: 0;
@@ -167,5 +167,19 @@
 
   .ct-label {
     font-size: .5em;
+  }
+}
+
+.plan-container {
+  .tooltip-inner {
+    border: 1px solid black;
+    background-color: #F8F9FA;
+    color: #545B62;
+  }
+  .tooltip-inner {
+    font-family: Karla, sans-serif;
+    font-size: 12px;
+    line-height: 14px;
+    letter-spacing: -0.2px;
   }
 }

--- a/app/javascript/src/controllers/plan_controller.js
+++ b/app/javascript/src/controllers/plan_controller.js
@@ -181,6 +181,13 @@ export default class extends Controller {
     return JSON.parse(this.activityMapTarget.value)
   }
 
+  // TODO: no test coverage for this yet because mocking jQuery ($) in the way.
+  initActivityCountButton() {
+    $(".activity-count-circle").click(() => {
+      $(".capacity-container").show()
+    })
+  }
+
   initBarChart() {
     this.chartLabels = JSON.parse(this.data.get("chartLabels"))
     let data = {
@@ -202,25 +209,38 @@ export default class extends Controller {
       },
     };
     this.chart = new Chartist.Bar(this.data.get("chartSelector"), data, options);
-    this.chart.on('created', this.setBarChartEventListeners.bind(this))
+    this.chart.on('created', () => {
+      this.initBarChartInteractivity()
+    })
   }
 
   // TODO: no test coverage for this yet because mocking jQuery ($) in the way.
-  setBarChartEventListeners() {
-    $("line.ct-bar").each((i, el) => {
-      let $el = $(el)
-      if (this.chartLabels[i]) {
-        $($el).on('click', () => {
-          $('.capacity-container').hide()
-          $('#capacity-' + this.chartLabels[i]).show()
-        })
-      }
+  initBarChartInteractivity() {
+    $("line.ct-bar").each((index, el) => {
+      let $elBarSegment = $(el)
+      this.initClickHandlerForTAChart($elBarSegment, index)
+      this.initTooltipForTAChartSegment($elBarSegment, index)
     })
   }
 
-  initActivityCountButton() {
-    $(".activity-count-circle").click(() => {
-      $(".capacity-container").show()
-    })
+  // TODO: no test coverage for this yet because mocking jQuery ($) in the way.
+  initClickHandlerForTAChart($elBarSegment, index) {
+    if (this.chartLabels[index]) {
+      $($elBarSegment).on('click', () => {
+        $('.capacity-container').hide()
+        $('#capacity-' + this.chartLabels[index]).show()
+      })
+    }
+  }
+
+  // TODO: no test coverage for this yet because mocking jQuery ($) in the way.
+  initTooltipForTAChartSegment($elBarSegment, index) {
+    let $elTitle = $('#capacity-' + this.chartLabels[index])
+    let tooltipTitle = $elTitle.attr("title") + ": " + $elBarSegment.attr("ct:value")
+    $elBarSegment
+        .attr("title", tooltipTitle)
+        .attr("data-toggle", "tooltip")
+        .tooltip({container: ".plan-container"})
+        .tooltip('show')
   }
 }

--- a/app/views/plans/_capacity.html.erb
+++ b/app/views/plans/_capacity.html.erb
@@ -1,5 +1,11 @@
-<div class="capacity-container" id="capacity-<%= chart_label %>">
-  <h2 id="<%= capacity[:name].parameterize %>"><%= capacity[:id] %>. <%= capacity[:name] %></h2>
+<div class="capacity-container"
+     id="capacity-<%= chart_label %>"
+     title="<%= capacity[:name] %>"
+>
+  <h2 id="<%= capacity[:name].parameterize %>">
+    <%= capacity[:id] %>.
+    <%= capacity[:name] %>
+  </h2>
   <% (@benchmarks.capacity_benchmarks capacity[:id]).each do |benchmark| %>
     <!-- -->
     <% activities = @plan.activity_map.benchmark_activities(benchmark[:id]) %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,12 +1,15 @@
 <%
-  chart_labels = %w(P1 P2 P3 P4 P5 P6 P7 D1 D2 D3 D4 R1 R2 R3 R4 R5 POE CE RE)
+  # NB: these labels come from the JEE1 but absent the P6 label cuz thats what
+  #   reflect the Benchmarks. This will probably be re-visited to use the actual
+  #   Indicator values from the actual Benchmarks, once those become available.
+  chart_labels = %w(P1 P2 P3 P4 P5 P7 D1 D2 D3 D4 R1 R2 R3 R4 R5 POE CE RE)
 %>
 
 <%= render "plan_review_modal" %>
 
 <div class="row">
   <div class="col plan-container" data-controller="plan"
-       data-plan-chart-selector="#bar-chart"
+       data-plan-chart-selector="#bar-chart-for-ta"
        data-plan-chart-labels="<%= chart_labels.to_json %>"
        data-plan-chart-series="<%= @plan.count_activities_by_capacity %>"
        data-plan-chart-width="730"
@@ -45,7 +48,8 @@
 
               <!-- Actual Bar Chart -->
               <h6 class="my-3">Actions per technical area</h6>
-              <div id="bar-chart" class="ct-chart-bar"></div>
+              <div id="bar-chart-for-ta" class="ct-chart-bar">
+              </div>
 
             </div>
 

--- a/test/javascript/plan_controller.test.js
+++ b/test/javascript/plan_controller.test.js
@@ -18,7 +18,7 @@ describe("PlanController", () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <div data-controller="plan"
-         data-plan-chart-selector="#bar-chart"
+         data-plan-chart-selector="#bar-chart-for-ta"
          data-plan-chart-labels='["P1","P2","P3","P4","P5","P6","P7","D1","D2","D3","D4","R1","R2","R3","R4","R5","POE","CE","RE"]'
          data-plan-chart-series="[3, 9, 19, 9, 11, 13, 19, 7, 15, 18, 11, 15, 7, 19, 20, 16, 14, 4]"
          data-plan-chart-width="730"
@@ -30,7 +30,7 @@ describe("PlanController", () => {
           <input id="name" data-action="change->plan#validateName" required>
         </form>
 
-        <div id="bar-chart" class="ct-chart-bar"></div>
+        <div id="bar-chart-for-ta" class="ct-chart-bar"></div>
 
         <div class="benchmark-container" id="capacity-p7">
           <div id="activity_container_1-1">
@@ -140,7 +140,7 @@ describe("PlanController", () => {
     })
 
     it("uses the expected DOM node for the chart", () => {
-      expect(controller.chart.container).toBe(document.getElementById("bar-chart"))
+      expect(controller.chart.container).toBe(document.getElementById("bar-chart-for-ta"))
     })
   })
 


### PR DESCRIPTION
- add JS code to initialize tooltips for the bar chart segments
- modify the ID for the bar chart to contain TA for Technical Areas since there will be other chart(s)
- remove "P6" from the chart_labels to align with actual benchmarks, include note why
- add styles for the TA bar chart to use Stacy's design / white and smaller
- re-arrange the .plan* classes to more easily understand to which page they pertain/CRUD

Fixes #169573506