### PR TITLE
[Scores Page] JEE & SPAR need to show indicators IDs #169919709

### DIFF
--- a/app/helpers/goals_helper.rb
+++ b/app/helpers/goals_helper.rb
@@ -1,0 +1,11 @@
+module GoalsHelper
+
+  ##
+  # takes an arg such as "jee1_ind_p12" and returns "P.1.2", or empty string
+  def abbrev_from_named_id(key)
+    return '' if key.blank?
+
+    key.reverse.split('_').first.reverse.upcase.chars.join('.')
+  end
+
+end

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -95,7 +95,7 @@
               <% technical_area = @assessments[@display_assessment_type]['technical_areas'][technical_area_id] %>
               <tr class="technical-area-<%= technical_area_id %>"
                   data-controller="score-and-goal">
-                <% indicator = technical_area['indicators'][0] %>
+                <% indicator_id = technical_area['indicators'][0] %>
                 <th
                   class="border-right"
                   scope="row"
@@ -103,12 +103,15 @@
                 >
                   <%= @data_dictionary[technical_area_id] %>
                 </th>
-                <td class="border-right"><%= @data_dictionary[indicator] %></td>
-                <td>
-                  <%= render "validated_field", field_name: indicator, f: f %>
+                <td class="border-right">
+                  <strong><%= abbrev_from_named_id(indicator_id) %></strong>
+                  <%= @data_dictionary[indicator_id] %>
                 </td>
                 <td>
-                  <%= render "validated_field", field_name: "#{indicator}_goal", f:
+                  <%= render "validated_field", field_name: indicator_id, f: f %>
+                </td>
+                <td>
+                  <%= render "validated_field", field_name: "#{indicator_id}_goal", f:
                   f %>
                 </td>
               </tr>
@@ -116,7 +119,10 @@
               <% technical_area['indicators'].drop(1).each do |indicator| %>
                 <tr class="technical-area-<%= technical_area_id %>"
                     data-controller="score-and-goal">
-                  <td class="border-right"><%= @data_dictionary[indicator] %></td>
+                  <td class="border-right">
+                    <strong><%= abbrev_from_named_id(indicator) %></strong>
+                    <%= @data_dictionary[indicator] %>
+                  </td>
                   <td>
                     <%= render "validated_field", field_name: indicator, f: f %>
                   </td>

--- a/test/helpers/goals_helper_test.rb
+++ b/test/helpers/goals_helper_test.rb
@@ -1,0 +1,55 @@
+require File.expand_path('./test/test_helper')
+
+class GoalsHelperTest < ActionView::TestCase
+  test '#abbrev_from_named_id handles empty string' do
+    assert_equal '', abbrev_from_named_id('')
+  end
+
+  test '#abbrev_from_named_id handles nil' do
+    assert_equal '', abbrev_from_named_id(nil)
+  end
+
+  test '#abbrev_from_named_id handles arg without an underscore' do
+    assert_equal 'P.1.2', abbrev_from_named_id('p12')
+  end
+
+  test '#abbrev_from_named_id handles arg without a value on the left' do
+    assert_equal 'P.1.2', abbrev_from_named_id('_p12')
+  end
+
+  test '#abbrev_from_named_id handles arg without a value to the right' do
+    assert_equal '', abbrev_from_named_id('jee1_')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee1_ta_p1' do
+      assert_equal 'P.1', abbrev_from_named_id('jee1_ta_p1')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee1_ta_poe' do
+      assert_equal 'P.O.E', abbrev_from_named_id('jee1_ta_poe')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee1_ind_p61' do
+      assert_equal 'P.6.1', abbrev_from_named_id('jee1_ind_p61')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee1_ind_re2' do
+      assert_equal 'R.E.2', abbrev_from_named_id('jee1_ind_re2')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee2_ta_ce' do
+      assert_equal 'C.E', abbrev_from_named_id('jee2_ta_ce')
+  end
+
+  test '#abbrev_from_named_id returns expected for jee2_ind_r42' do
+      assert_equal 'R.4.2', abbrev_from_named_id('jee2_ind_r42')
+  end
+
+  test '#abbrev_from_named_id returns expected for spar_2018_ta_c13' do
+      assert_equal 'C.1.3', abbrev_from_named_id('spar_2018_ta_c13')
+  end
+
+  test '#abbrev_from_named_id returns expected for spar_2018_ind_c111' do
+      assert_equal 'C.1.1.1', abbrev_from_named_id('spar_2018_ind_c111')
+  end
+end

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -19,7 +19,7 @@ class AppsTest < ApplicationSystemTestCase
 
     assert page.has_content?('SPAR 2018 SCORES')
     assert page.has_content?(
-             'Financing mechanism and funds for timely response to public health emergencies'
+             'C.1.3 Financing mechanism and funds for timely response to public health emergencies'
            )
     assert_equal '3', find('#goal_form_spar_2018_ind_c13').value
     assert_equal '4', find('#goal_form_spar_2018_ind_c13_goal').value


### PR DESCRIPTION
- add GoalsHelper and method abbrev_from_named_id, e.g. jee1_ind_p12 to "P.1.2"
- modify the goals/show template to include the new indicator abbreviations in bold
- add new test class for the new helper class
- add an assertion in the capybara test for this too

Fixes #169919709