### PR TITLE
[Draft Plan] Show tooltip on hover on the Activity Type chart #169956534

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -144,6 +144,7 @@
 }
 
 .plan.card {
+  // ct-* are chartist style class we are overriding
   .ct-vertical {
     stroke: #C3C9D8;
     stroke-dasharray: 0;
@@ -165,7 +166,25 @@
   }
 
   .ct-label {
-    font-size: .5em;
+    font-size: 11px;
+  }
+
+  #bar-chart-by-activity-type {
+    // needs more bottom margin to allow the angled labels to display w/o cutoff
+    .ct-chart-bar {
+      overflow: visible;
+      margin : 0 0 90px 0;
+    }
+
+    // labels for chart by activity type at 45º angle per design
+    .ct-label.ct-horizontal {
+      position: fixed; // makes the labels and their position scale/zoom well
+      justify-content: flex-end;
+      text-align: right;
+      transform-origin: right;
+      transform: rotate(-45deg);
+      white-space: nowrap;
+    }
   }
 }
 

--- a/app/views/plans/_activity.html.erb
+++ b/app/views/plans/_activity.html.erb
@@ -7,13 +7,13 @@
       <span class="activity-level"><%= benchmark_activity_level %></span>
     </span>
   </div>
-  <div class="col-11">
+  <div class="col-10">
     <strong><%= display_abbreviation %></strong>
     <span class="activity-text">
       <%= benchmark_activity_text %>
     </span>
   </div>
-  <div class="col-1">
+  <div class="col">
     <button
       class="delete close"
       type="button"

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -6,7 +6,7 @@
 
   <div class="col plan-container" data-controller="plan"
        data-plan-chart-selectors='["#bar-chart-by-technical-area", "#bar-chart-by-activity-type"]'
-       data-plan-chart-labels='[<%= chart_labels_by_technical_area %>, <%= Array.new(15, "") %>]'
+       data-plan-chart-labels='[<%= chart_labels_by_technical_area %>, <%= BenchmarkIndicatorActivity::ACTIVITY_TYPES.to_json %>]'
        data-plan-chart-series='[<%= @plan.count_activities_by_ta %>, <%= @plan.count_activities_by_type %>]'
        data-plan-chart-width="730"
        data-plan-chart-height="240"


### PR DESCRIPTION
- Tooltips working for bar segments on chart for activity type, same style as chart by technical area
- Labels for the X-axis at 45º, plus ensure the labels handle zoom +/- well
- Fix X-close button jumping around on hover
- Add getNextMultipleOfTenForSeries functiion to make chart Y-axis scale dynamicly per the max value in the data set

Fixes #169956534