### PR TITLE
[Scores Page] Remove the "Get to Green" box #169607204

### DIFF
--- a/app/assets/stylesheets/scores.scss
+++ b/app/assets/stylesheets/scores.scss
@@ -35,7 +35,7 @@
   .tooltip-inner {
     background: color("red");
   }
-  .arrow::before {
+  .arrow:before {
     border-top-color: color("red");
   }
 }
@@ -43,29 +43,6 @@
 .scores-widget {
   max-height: 156px;
   margin: auto;
-}
-
-.get-to-green {
-  height: 81px;
-
-  .gtg-text-field {
-    font-family: Pathway Gothic One;
-    font-size: 24px;
-    line-height: 28px;
-    padding-top: 26px;
-    padding-bottom: 27px;
-  }
-
-  .gtg-button-field {
-    padding-top: 22px;
-    padding-bottom: 23px;
-
-    .btn {
-      font-family: Karla, sans-serif;
-      min-width: 180px;
-      height: 36px;
-    }
-  }
 }
 
 .goals-next-button {

--- a/app/javascript/src/controllers/score_controller.js
+++ b/app/javascript/src/controllers/score_controller.js
@@ -21,13 +21,6 @@ export default class extends Controller {
     this.childControllers = []
   }
 
-  getToGreen(e) {
-    document.querySelectorAll("[data-goal=true]").forEach(field => {
-      if (field.value < 4) field.value = 4
-      this.setFieldColor(field)
-    })
-  }
-
   setFieldColor(field) {
     field.classList.remove(
       ...Array.from(field.classList).filter(c => c.match("color-score"))
@@ -52,8 +45,8 @@ export default class extends Controller {
    * The logic here is a little confusing, and it might be easier to call
    * `this.form.submit()` directly.
    */
-  submit(e) {
-    const { currentTarget: form } = e
+  submit(event) {
+    const { currentTarget: form } = event
     if (form.checkValidity() === false) {
       event.preventDefault()
       event.stopPropagation()

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -60,18 +60,6 @@
       </div>
     </div>
 
-    <div class="row get-to-green m-0 align-center bg-light-gray">
-      <div class="col-10 gtg-text-field">
-        Want to see what it takes to achieve demonstrated capacity? Change all your goals to 4 with just one click.
-      </div>
-      <div class="col-2 d-flex justify-content-end gtg-button-field">
-        <%= button_tag "Get to Green!",
-          type: "button",
-          class: "btn text-white bg-green",
-          data: { action: "click->score#getToGreen" } %>
-      </div>
-    </div>
-
     <div class="row">
       <div class="col">
         <table class="table table-fixed table-scores border-bottom w-100">

--- a/app/views/shared/_assessment_selection_modal.html.erb
+++ b/app/views/shared/_assessment_selection_modal.html.erb
@@ -40,14 +40,20 @@
 
         <%= form_tag '/country_select', id: "assessment-select-menu",
           data: { target: "assessment-selection.form" } do %>
-          <%= hidden_field_tag "country",
-            nil,
-            data: { target: "assessment-selection.countryName" }
+          <%= hidden_field_tag(
+                  "country",
+                  nil,
+                  {
+                      id:   "country_for_assessment_selection_modal",
+                      data: {target: "assessment-selection.countryName"}
+                  },
+              )
           %>
           <div class="input-group mb-4">
             <%= select_tag "assessment_type",
               options_from_collection_for_select([], 'assessment_type', 'assessment_type'),
               class: "custom-select",
+              id: "assessment_type_for_modal",
               data: { target: "assessment-selection.assessmentTypeSelect",
                       action: "assessment-selection#validateAndEnableNext" }
             %>

--- a/app/views/shared/_capacity_selection_modal.html.erb
+++ b/app/views/shared/_capacity_selection_modal.html.erb
@@ -25,6 +25,7 @@
             data: { action: "assessment-selection.form" } do %>
           <%= hidden_field_tag "country",
             nil,
+            id: "country_for_capacity_selection_modal",
             data: { target: "assessment-selection.countryName" }
           %>
           <%= hidden_field_tag "assessment_type", "from-capacities" %>

--- a/app/views/shared/_joint_assessment_selection_modal.html.erb
+++ b/app/views/shared/_joint_assessment_selection_modal.html.erb
@@ -37,12 +37,12 @@
           <strong>Create a plan by a recent assessment or by capacity areas:</strong>
         </p>
 
-        <%= form_tag '/country_select', id: "assessment-select-menu",
-          data: { target: "assessment-selection.form" } do %>
+        <%= form_tag '/country_select', id: "assessment-select-menu", data: { target: "assessment-selection.form" } do %>
           <div class="input-group mb-4">
             <%= select_tag "country",
               options_from_collection_for_select(@countries, 'name', 'name'),
               class: "custom-select",
+              id: "country_for_joint_assessment_modal",
               data: { target: "assessment-selection.countrySelect",
                       action: "assessment-selection#selectCountry
                                assessment-selection#validateAndEnableNext"

--- a/test/javascript/score_controller.test.js
+++ b/test/javascript/score_controller.test.js
@@ -76,42 +76,4 @@ describe("ScoreController", () => {
     })
   })
 
-  describe("#go-to-green", () => {
-    beforeEach(() => {
-      document.body.innerHTML = `
-      <div data-controller="score">
-        <button type="button" data-action="click->score#getToGreen" id="gtg"></button>
-        <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
-        <input id="score1"      type="number" value="1" class="color-score-1" />
-        <input id="score1_goal" type="number" value="2" class="color-score-2" data-goal="true" />
-        <input id="score2"      type="number" value="1" class="color-score-1" />
-        <input id="score2_goal" type="number" value="2" class="color-score-2" data-goal="true" />
-        <input id="score3"      type="number" value="4" class="color-score-4" />
-        <input id="score3_goal" type="number" value="5" class="color-score-5" data-goal="true" />
-        <input id="submit" type="submit" data-target="score.submitButton" />
-      </div>
-      `
-      const application = Application.start()
-      application.register("score", ScoreController)
-    })
-
-    it("sets the value to 4 and sets the correct color", () => {
-      const gtgButton = document.getElementById("gtg")
-      gtgButton.click()
-
-      expect(document.getElementById("score1").value).toEqual("1")
-      expect(document.getElementById("score1_goal").value).toEqual("4")
-      expect(document.getElementById("score1_goal").className).toEqual(
-        "color-score-4"
-      )
-      expect(document.getElementById("score2_goal").value).toEqual("4")
-      expect(document.getElementById("score2_goal").className).toEqual(
-        "color-score-4"
-      )
-      expect(document.getElementById("score3_goal").value).toEqual("5")
-      expect(document.getElementById("score3_goal").className).toEqual(
-        "color-score-5"
-      )
-    })
-  })
 })


### PR DESCRIPTION
- remove JS code for the getToGreen method. fix event argument was poorly named and mis-referenced and probably caused an error.
- remove styles for .get-to-green class and children. also remove double colon which was prob a typo
- remove markup for .get-to-green from the goals/show view template and test
- fix 2 occurences of DOM element IDs being non-unique: country (3 instances), and assessment_type (2 instances). things appear to still work.