### PR TITLE
[Draft Plan] Chart needs to update if user adds/remove activities #169956748

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -64,6 +64,11 @@
   }
 }
 
+.benchmark-container .row,
+.activity.row {
+  border: 1px solid color("light-gray");
+}
+
 .benchmark-container {
   margin-bottom: 50px;
 
@@ -96,11 +101,6 @@
       border: none;
     }
   }
-}
-
-.benchmark-container .row,
-.activity.row {
-  border: 1px solid color("light-gray");
 }
 
 .activity.row {

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -22,6 +22,7 @@ class PlansController < ApplicationController
   def show
     @benchmark_technical_areas = BenchmarkTechnicalArea.all
     @benchmark_indicators = BenchmarkIndicator.all
+    @technical_area_abbrev_map = BenchmarkTechnicalArea.to_abbreviation_map
     @plan = Plan.find(params.fetch(:id))
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,0 @@
-module ApplicationHelper
-  def benchmark_ta_abbreviations
-    BenchmarkTechnicalArea.to_abbreviations
-  end
-end

--- a/app/javascript/src/controllers/activity_controller.js
+++ b/app/javascript/src/controllers/activity_controller.js
@@ -9,15 +9,20 @@ export default class extends Controller {
     this.parentController.childControllers.push(this)
   }
 
+  connect() {
+    this.technicalAreaId = Number(this.data.get("technicalAreaId"))
+    this.indicatorId = Number(this.data.get("indicatorId"))
+    this.id = Number(this.data.get("id"))
+    this.barSegmentIndex = Number(this.data.get("barSegmentIndex"))
+  }
+
   deleteSelf(e) {
     const { currentTarget } = e
-    const planActivityIdToRemove = Number(currentTarget.getAttribute("data-benchmark-activity-id"))
-    console.log("GVT: planActivityIdToRemove: ", planActivityIdToRemove)
-    this.removeActivityId(planActivityIdToRemove)
+    this.removeActivityId(this.id, {barSegmentIndex: this.barSegmentIndex})
     currentTarget.closest(".row").classList.add("d-none")
   }
 
-  removeActivityId(activityId) {
-    this.parentController.removeActivityId(activityId)
+  removeActivityId(activityId, data) {
+    this.parentController.removeActivityId(activityId, data)
   }
 }

--- a/app/javascript/src/controllers/benchmark_controller.js
+++ b/app/javascript/src/controllers/benchmark_controller.js
@@ -16,8 +16,10 @@ export default class extends Controller {
 
   connect() {
     this.deleteTarget.hidden = true
-    this.benchmarkIndicatorId = this.data.get("indicator-id")
-    this.benchmarkAbbreviation = this.data.get("indicator-abbreviation")
+    this.technicalAreaId = Number(this.data.get("technicalAreaId"))
+    this.indicatorId = Number(this.data.get("indicatorId"))
+    this.indicatorDisplayAbbrev = Number(this.data.get("indicatorDisplayAbbrev"))
+    this.barSegmentIndex = Number(this.data.get("barSegmentIndex"))
     this.initAutoCompleteForAddActivity()
   }
 
@@ -36,18 +38,30 @@ export default class extends Controller {
         select: function(event, ui) {
           const benchmarkActivity = ui.item
           self.addActivityAndRender(benchmarkActivity)
+          // remove the selected activity from the set of activities that appears in tha autocomplete menu
+          const excludedActivities = JSON.parse(self.data.get("excluded-activities"))
+          const selectedActivity = excludedActivities.find((a) => {
+            return a.id === benchmarkActivity.id
+          })
+          const indexOfActivity = excludedActivities.indexOf(selectedActivity)
+          excludedActivities.splice(indexOfActivity, 1)
+          self.data.set("excluded-activities", JSON.stringify(excludedActivities))
+          self.initAutoCompleteForAddActivity()
         }
       })
     }
   }
 
   addActivityAndRender(benchmarkActivity) {
-    this.addActivityId(benchmarkActivity.id)
+    this.addActivityId(benchmarkActivity.id, {barSegmentIndex: this.barSegmentIndex})
     const templateData = {
+      benchmarkTechnicalAreaId: this.technicalAreaId,
+      benchmarkIndicatorId: this.indicatorId,
+      indicatorDisplayAbbrev: this.indicatorDisplayAbbrev,
       benchmarkActivityId: benchmarkActivity.id,
-      displayAbbreviation: this.benchmarkAbbreviation,
       benchmarkActivityLevel: benchmarkActivity.level,
       benchmarkActivityText: benchmarkActivity.text,
+      barSegmentIndex: this.barSegmentIndex
     }
     const activityRowTemplateSelector = this.data.get("activityRowTemplateSelector")
     const compiledTemplate = this.getTemplateFor(activityRowTemplateSelector)
@@ -89,7 +103,7 @@ export default class extends Controller {
     const { currentTarget } = e
     const activityIds = JSON.parse(this.data.get("activityIds"))
     activityIds.forEach((activityId) => {
-      this.removeActivityId(activityId)
+      this.removeActivityId(activityId, {barSegmentIndex: this.barSegmentIndex})
     })
     this.element.hidden = true
     const siblings = $(this.element).siblings(".benchmark-container:visible")
@@ -98,12 +112,12 @@ export default class extends Controller {
     }
   }
 
-  addActivityId(activityId) {
-    this.parentController.addActivityId(activityId)
+  addActivityId(activityId, data) {
+    this.parentController.addActivityId(activityId, data)
   }
 
-  removeActivityId(activityId) {
-    this.parentController.removeActivityId(activityId)
+  removeActivityId(activityId, data) {
+    this.parentController.removeActivityId(activityId, data)
   }
 
   hasActivities() {

--- a/app/models/benchmark_indicator_activity.rb
+++ b/app/models/benchmark_indicator_activity.rb
@@ -6,6 +6,8 @@ class BenchmarkIndicatorActivity < ApplicationRecord
 
   default_scope { order(:sequence) }
 
+  delegate :benchmark_technical_area_id, to: :benchmark_indicator
+
   # Note that these values are 0-indexed but in the DB they are 1-indexed
   ACTIVITY_TYPES = [
     "Advocacy",
@@ -30,6 +32,7 @@ class BenchmarkIndicatorActivity < ApplicationRecord
     {
       id: nil,
       benchmark_indicator_id: nil,
+      benchmark_technical_area_id: nil,
       text: nil,
       level: nil,
       sequence: nil,

--- a/app/models/benchmark_technical_area.rb
+++ b/app/models/benchmark_technical_area.rb
@@ -5,7 +5,15 @@ class BenchmarkTechnicalArea < ApplicationRecord
 
   default_scope { includes(:benchmark_indicators).order(:sequence) }
 
-  def self.to_abbreviations
-    all.map { |bta| "B#{bta.sequence}" }
+  def self.to_abbreviation_map
+    abbreviation_map = {}
+    all.each do |bta|
+      abbreviation_map[bta.to_abbreviation] = bta.id
+    end
+    abbreviation_map
+  end
+
+  def to_abbreviation
+    "B#{sequence}"
   end
 end

--- a/app/views/plans/_activity.html.erb
+++ b/app/views/plans/_activity.html.erb
@@ -1,7 +1,10 @@
 <div
   data-controller="activity"
   data-target="benchmark.activity"
-  data-benchmark-activity-id="<%= benchmark_activity_id %>"
+  data-activity-technical-area-id="<%= benchmark_technical_area_id %>"
+  data-activity-indicator-id="<%= benchmark_indicator_id %>"
+  data-activity-id="<%= benchmark_activity_id %>"
+  data-activity-bar-segment-index="<%= bar_segment_index %>"
   class="activity row p-2 <%= activity_type_classes %>"
 >
   <div class="col-auto d-flex flex-row align-items-center">
@@ -10,7 +13,7 @@
     </span>
   </div>
   <div class="col-10">
-    <strong><%= display_abbreviation %></strong>
+    <strong><%= indicator_display_abbrev %></strong>
     <span class="activity-text">
       <%= benchmark_activity_text %>
     </span>
@@ -20,7 +23,6 @@
       class="delete close"
       type="button"
       data-action="activity#deleteSelf"
-      data-benchmark-activity-id="<%= benchmark_activity_id %>"
     >
       <img src="/delete-button.svg" alt="Delete this activity"/>
     </button>

--- a/app/views/plans/_benchmark_indicator.html.erb
+++ b/app/views/plans/_benchmark_indicator.html.erb
@@ -1,14 +1,17 @@
 <% plan_indicator, indicator_score, indicator_goal = @plan.indicator_score_goal_for(benchmark_indicator) %>
 <% plan_indicator_activities = @plan.activities_for(benchmark_indicator) || [] %>
+<% bar_segment_index = benchmark_technical_area.sequence - 1 %>
 
 <div
   data-controller="benchmark"
   data-target="benchmark.self"
+  data-benchmark-technical-area-id="<%= benchmark_technical_area.id %>"
   data-benchmark-indicator-id="<%= benchmark_indicator.id %>"
-  data-benchmark-indicator-abbreviation="<%= benchmark_indicator.display_abbreviation %>"
+  data-benchmark-indicator-display-abbrev="<%= benchmark_indicator.display_abbreviation %>"
   data-benchmark-excluded-activities="<%= @plan.excluded_activities_for(benchmark_indicator).to_json %>"
   data-benchmark-activity-row-template-selector="#activity-row-template"
   data-benchmark-activity-ids="<%= plan_indicator_activities.map { |pia| pia.benchmark_indicator_activity_id } %>"
+  data-benchmark-bar-segment-index="<%= bar_segment_index %>"
   class="benchmark-container col"
 >
   <div class="row bg-light-gray px-2 header">
@@ -45,11 +48,14 @@
     <% plan_indicator_activities.each do |plan_activity| %>
       <% benchmark_activity = plan_activity.benchmark_indicator_activity %>
       <%= render "activity",
-                 benchmark_activity_id:    benchmark_activity.id,
-                 display_abbreviation:     benchmark_indicator.display_abbreviation,
-                 benchmark_activity_level: benchmark_activity.level,
-                 benchmark_activity_text:  benchmark_activity.text,
-                 activity_type_classes:    benchmark_activity.activity_types.map { |type_num| "activity-type-#{type_num}" }.join(" ")
+                 bar_segment_index:           bar_segment_index,
+                 benchmark_technical_area_id: benchmark_technical_area.id,
+                 benchmark_indicator_id:      benchmark_indicator.id,
+                 indicator_display_abbrev:    benchmark_indicator.display_abbreviation,
+                 benchmark_activity_id:       benchmark_activity.id,
+                 benchmark_activity_level:    benchmark_activity.level,
+                 benchmark_activity_text:     benchmark_activity.text,
+                 activity_type_classes:       benchmark_activity.activity_types.map { |type_num| "activity-type-#{type_num}" }.join(" ")
       %>
     <% end %>
 

--- a/app/views/plans/_technical_area.html.erb
+++ b/app/views/plans/_technical_area.html.erb
@@ -1,6 +1,8 @@
 <div class="technical-area-container"
      id="technical-area-<%= chart_label %>"
      title="<%= benchmark_technical_area.text %>"
+     data-technical-area-id="<%= benchmark_technical_area.id %>"
+     data-target="plan.technicalAreaContainer"
 >
   <% unless @plan.from_technical_areas? %>
     <h2 id="<%= benchmark_technical_area.text.parameterize %>">
@@ -10,7 +12,10 @@
   <% end %>
 
   <% benchmark_technical_area.benchmark_indicators.each do |benchmark_indicator| %>
-    <%= render 'benchmark_indicator', benchmark_indicator: benchmark_indicator %>
+    <%= render 'benchmark_indicator',
+               benchmark_technical_area: benchmark_technical_area,
+               benchmark_indicator: benchmark_indicator
+    %>
   <% end %>
 
 </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,4 +1,4 @@
-<% chart_labels_by_technical_area = benchmark_ta_abbreviations %>
+<% chart_labels_by_technical_area = @technical_area_abbrev_map.keys %>
 
 <%= render "plan_review_modal" %>
 
@@ -11,6 +11,7 @@
        data-plan-chart-width="730"
        data-plan-chart-height="240"
        data-plan-activity-ids='<%= @plan.benchmark_indicator_activity_ids.to_json %>'
+       data-plan-technical-area-map="<%= @technical_area_abbrev_map.to_json %>"
   >
     <%= form_for @plan, class: "needs-validation", novalidate: true, data: { target: "plan.form" } do |form| %>
       <%= form.hidden_field :benchmark_activity_ids,
@@ -102,11 +103,14 @@
 
   <script type="text/template" id="activity-row-template">
     <%= render "activity",
-               benchmark_activity_id:    "{{benchmarkActivityId}}",
-               display_abbreviation:     "{{displayAbbreviation}}",
-               benchmark_activity_level: "{{benchmarkActivityLevel}}",
-               benchmark_activity_text:  "{{benchmarkActivityText}}",
-               activity_type_classes:    "{{benchmarkActivityTypes}}"
+               benchmark_technical_area_id: "{{benchmarkTechnicalAreaId}}",
+               bar_segment_index:           "{{barSegmentIndex}}",
+               benchmark_indicator_id:      "{{benchmarkIndicatorId}}",
+               indicator_display_abbrev:    "{{indicatorDisplayAbbrev}}",
+               benchmark_activity_id:       "{{benchmarkActivityId}}",
+               benchmark_activity_level:    "{{benchmarkActivityLevel}}",
+               benchmark_activity_text:     "{{benchmarkActivityText}}",
+               activity_type_classes:       "{{benchmarkActivityTypes}}"
     %>
   </script>
 </div>

--- a/test/javascript/plan_controller.test.js
+++ b/test/javascript/plan_controller.test.js
@@ -124,28 +124,28 @@ describe("PlanController", () => {
       controller = application.controllers[0]
     })
 
-    it("defaults currentIndex to zero", () => {
-      expect(controller.currentIndex).toEqual(0)
+    it("defaults currentChartIndex to zero", () => {
+      expect(controller.currentChartIndex).toEqual(0)
     })
 
     it("constructs a Chartist.Bar instance", () => {
-      expect(controller.charts[controller.currentIndex]).toBeInstanceOf(Chartist.Bar)
+      expect(controller.charts[controller.currentChartIndex]).toBeInstanceOf(Chartist.Bar)
     })
 
     it("populates the array of labels", () => {
-      expect(controller.chartLabels[controller.currentIndex].length).toBe(18)
+      expect(controller.chartLabels[controller.currentChartIndex].length).toBe(18)
     })
 
     it("has the expected width", () => {
-      expect(controller.charts[controller.currentIndex].options.width).toBe("730")
+      expect(controller.charts[controller.currentChartIndex].options.width).toBe("730")
     })
 
     it("has the expected height", () => {
-      expect(controller.charts[controller.currentIndex].options.height).toBe("240")
+      expect(controller.charts[controller.currentChartIndex].options.height).toBe("240")
     })
 
     it("uses the expected DOM node for the chart", () => {
-      expect(controller.charts[controller.currentIndex].container).toBe(document.getElementById("bar-chart-by-technical-area"))
+      expect(controller.charts[controller.currentChartIndex].container).toBe(document.getElementById("bar-chart-by-technical-area"))
     })
   })
 

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -165,18 +165,18 @@ class AppsTest < ApplicationSystemTestCase
     assert_equal "Nigeria draft plan", find("#plan_name").value
     assert page.has_content?("TOTAL ACTIVITIES")
     assert_equal "33", find(".activity-count-circle span").text
-    assert_selector("div[data-benchmark-indicator-abbreviation='1.1']")
-    assert_selector("div[data-benchmark-indicator-abbreviation='9.1']")
+    assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
+    assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     # verify bar chart by technical area filter functionality
     find('line[data-original-title*="Surveillance"]').click
-    assert_no_selector("div[data-benchmark-indicator-abbreviation='1.1']")
-    assert_selector("div[data-benchmark-indicator-abbreviation='9.1']")
+    assert_no_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
+    assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     # unfilter to show all
     find(".activity-count-circle").click
-    assert_selector("div[data-benchmark-indicator-abbreviation='1.1']")
-    assert_selector("div[data-benchmark-indicator-abbreviation='9.1']")
+    assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
+    assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     find("#plan_name").fill_in with: "Updated Plan 789"
     find("input[type=submit]").trigger(:click)


### PR DESCRIPTION
- Fix orange-ish border for the add activity form that was overridden by a previous change by changing the order
- add method BenchmarkTechnicalArea.to_abbreviation_map to connect chart abbreviations to IDs for use in views
- add to JS controllers on Plan page setting of instance variables to set basic attributes at controller start/connect to DOM
- fix bug where activity chosen via autocomplete would continue to appear after it was added. now it is removed from autocomplete choices
- add to addActivityId and removeActivityId methods a data payload so that child controllers can pass related info up the chain
- add methods to Plan JS controller incrementActivityCount and decrementActivityCount to +/- by one from the given chart index
- add method to Plan JS controller updateChart to use the Chartist API to update existing chart from its data by reference
- rename currentIndex to currentChartIndex for to better describe itself
- modify the JSON definition of a BenchmarkIndicatorActivity to include its benchmark_technical_area_id for grouping purposes
- Remove unused ApplicationHelper