### PR TITLE
Optimize time for plan create, show #170984108

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "rack-attack"
 gem "bootstrap", "~> 4.3.1"
 gem "jquery-rails"
 gem "hamlit-rails"
+# skylight.io is a performance analysis tool, our free trial expires on 2020-02-29.
+gem "skylight"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,10 @@ GEM
     sentry-raven (2.11.0)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.13.0)
+    skylight (4.2.1)
+      skylight-core (= 4.2.1)
+    skylight-core (4.2.1)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -311,6 +315,7 @@ DEPENDENCIES
   rubocop-rails
   rubyXL
   sentry-raven
+  skylight
   spring
   spring-watcher-listen (~> 2.0.0)
   standard

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -192,11 +192,14 @@ td {
   }
   a.btn {
     width: 250px;
-    height: 4.5em;
-    line-height: 4.5em;
-    padding: 0;
-    margin: 0;
   }
+}
+
+a.cta-btn {
+  height: 4.5em !important;
+  line-height: 4.5em;
+  padding: 0;
+  margin: 0;
 }
 
 .display-header {

--- a/app/lib/get_started_form.rb
+++ b/app/lib/get_started_form.rb
@@ -34,14 +34,20 @@ class GetStartedForm
   end
 
   def set_country
-    self.country = Country.find_by_id country_id
+    if country_id.present?
+      # we use the +with_assessments_and_publication+ method here because we want to
+      # fetch additional data to optimize for which data the view template will use.
+      self.country = Country.with_assessments_and_publication(country_id)
+    end
   end
 
   def set_assessment
     if country.present? && assessment_type.present? && is_known?(assessment_type)
       assessment_publication = AssessmentPublication.find_by_named_id(assessment_type)
       if assessment_publication.present?
-        self.assessment = Assessment.find_by_country_alpha3_and_assessment_publication_id(country.alpha3, assessment_publication.id)
+        # we use the +with_publication+ method here because we want to
+        # fetch additional data to optimize for which data the view template will use.
+        self.assessment = Assessment.with_publication(country.alpha3, assessment_publication.id)
       end
     end
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -8,7 +8,17 @@ class Assessment < ApplicationRecord
   belongs_to :country, foreign_key: "country_alpha3", primary_key: "alpha3"
   has_many :scores, class_name: "AssessmentScore"
   has_many :plans
-  default_scope { includes(:country).order("country_alpha3") }
+  default_scope { order("country_alpha3") }
+
+  scope :with_publication, -> (country_alpha3, assessment_publication_id) {
+    includes(:assessment_publication)
+      .find_by_country_alpha3_and_assessment_publication_id(country_alpha3, assessment_publication_id)
+  }
+
+  scope :deep_load, -> (country_alpha3, assessment_publication_id) {
+    includes({scores: :assessment_indicator})
+      .with_publication(country_alpha3, assessment_publication_id)
+  }
 
   delegate :jee1?, :spar_2018?, :type_description, to: :assessment_publication
 

--- a/app/models/benchmark_document.rb
+++ b/app/models/benchmark_document.rb
@@ -1,0 +1,11 @@
+class BenchmarkDocument
+
+  attr_reader :technical_areas, :indicators, :activities
+
+  def initialize
+    @technical_areas = BenchmarkTechnicalArea.includes({benchmark_indicators: :activities}).all
+    @indicators = @technical_areas.map(&:benchmark_indicators).flatten
+    @activities = @indicators.map(&:activities).flatten
+  end
+
+end

--- a/app/models/benchmark_technical_area.rb
+++ b/app/models/benchmark_technical_area.rb
@@ -5,9 +5,10 @@ class BenchmarkTechnicalArea < ApplicationRecord
 
   default_scope { includes(:benchmark_indicators).order(:sequence) }
 
-  def self.to_abbreviation_map
+  def self.to_abbreviation_map(benchmark_technical_areas = nil)
     abbreviation_map = {}
-    all.each do |bta|
+    technical_areas = benchmark_technical_areas.blank? ? all: benchmark_technical_areas
+    technical_areas.each do |bta|
       abbreviation_map[bta.to_abbreviation] = bta.id
     end
     abbreviation_map

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -5,6 +5,11 @@ class Country < ApplicationRecord
 
   default_scope { order(:name) }
   scope :all_assessed, -> { joins(:assessments).distinct.all }
+  scope :with_assessments_and_publication, ->(country_id) {
+    includes(assessments: :assessment_publication)
+      .where(id: country_id)
+      .first
+  }
 
   def attributes
     {

--- a/app/models/plan_activity.rb
+++ b/app/models/plan_activity.rb
@@ -1,6 +1,8 @@
 class PlanActivity < ApplicationRecord
   belongs_to :plan
   belongs_to :benchmark_indicator_activity
+  belongs_to :benchmark_indicator
+  belongs_to :benchmark_technical_area
 
   default_scope { includes(:benchmark_indicator_activity).order("benchmark_indicator_activities.level", "benchmark_indicator_activities.sequence") }
 

--- a/app/models/plan_goal.rb
+++ b/app/models/plan_goal.rb
@@ -2,6 +2,4 @@ class PlanGoal < ApplicationRecord
   belongs_to :plan
   belongs_to :assessment_indicator
   belongs_to :benchmark_indicator
-
-  default_scope { includes(:assessment_indicator) }
 end

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -22,5 +22,5 @@
             analysis of your actions.
       .row.my-4
         .col-8
-          = link_to "Get Started", get_started_url, class: "btn btn-success", type: "button"
+          = link_to "Get Started", get_started_url, class: "btn btn-success cta-btn", style: "width: 250px", type: "button"
     .col.right-panel.m-auto= render "hero_image"

--- a/app/views/plans/assessment_not_found.html.haml
+++ b/app/views/plans/assessment_not_found.html.haml
@@ -1,3 +1,3 @@
 .col
   %h2
-    There is no "#{@assessment_type}" assessment available for #{@country_name}.
+    There is no "#{params[:assessment_type]}" assessment available for #{params[:country_name]}.

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -4,7 +4,7 @@
       <h1>WELCOME</h1>
     </div>
     <div class="col-2 pl-0 py-4">
-      <%= button_to "CREATE PLAN", get_started_url, class: "btn btn-primary btn-block", type: "button", method: :get %>
+      <%= link_to "CREATE PLAN", get_started_url, class: "btn btn-success cta-btn", type: "button", style: "width: 220px" %>
     </div>
   </div>
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -10,7 +10,7 @@
        data-plan-nudge-content-zero-selector='#nudge-content-zero'
        data-plan-chart-selectors='["#bar-chart-by-technical-area", "#bar-chart-by-activity-type"]'
        data-plan-chart-labels='<%= [chart_labels_by_technical_area, BenchmarkIndicatorActivity::ACTIVITY_TYPES].to_json %>'
-       data-plan-chart-series='<%= [@plan.count_activities_by_ta, @plan.count_activities_by_type].to_json %>'
+       data-plan-chart-series='<%= [@count_activities_by_ta, @count_activities_by_type].to_json %>'
        data-plan-chart-width="710"
        data-plan-chart-height="240"
   >

--- a/db/migrate/20200202214510_add_more_ids_to_plan_activity_for_performance.rb
+++ b/db/migrate/20200202214510_add_more_ids_to_plan_activity_for_performance.rb
@@ -1,0 +1,8 @@
+class AddMoreIdsToPlanActivityForPerformance < ActiveRecord::Migration[5.2]
+  def change
+    add_column :plan_activities, :benchmark_indicator_id, :integer
+    add_column :plan_activities, :benchmark_technical_area_id, :integer
+    add_foreign_key :plan_activities, :benchmark_indicators
+    add_foreign_key :plan_activities, :benchmark_technical_areas
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_27_161252) do
+ActiveRecord::Schema.define(version: 2020_02_02_214510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,8 @@ ActiveRecord::Schema.define(version: 2020_01_27_161252) do
     t.integer "benchmark_indicator_activity_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "benchmark_indicator_id"
+    t.integer "benchmark_technical_area_id"
     t.index ["plan_id"], name: "index_plan_activities_on_plan_id"
   end
 
@@ -165,6 +167,8 @@ ActiveRecord::Schema.define(version: 2020_01_27_161252) do
   add_foreign_key "benchmark_indicator_activities", "benchmark_indicators"
   add_foreign_key "benchmark_indicators", "benchmark_technical_areas"
   add_foreign_key "plan_activities", "benchmark_indicator_activities"
+  add_foreign_key "plan_activities", "benchmark_indicators"
+  add_foreign_key "plan_activities", "benchmark_technical_areas"
   add_foreign_key "plan_activities", "plans"
   add_foreign_key "plan_goals", "assessment_indicators"
   add_foreign_key "plan_goals", "benchmark_indicators"

--- a/test/fixtures/files/plan_for_nigeria_jee1/README.md
+++ b/test/fixtures/files/plan_for_nigeria_jee1/README.md
@@ -26,5 +26,5 @@ Then, within the `psql` command client:
 \pset format unaligned
 WITH t AS (select name, assessment_id from plans) SELECT json_agg(t) FROM t;
 WITH t AS (SELECT plan_id, assessment_indicator_id, benchmark_indicator_id, value FROM plan_goals) SELECT json_agg(t) FROM t;
-WITH t AS (SELECT plan_id, benchmark_indicator_activity_id FROM plan_activities) SELECT json_agg(t) FROM t;
+WITH t AS (SELECT plan_id, benchmark_indicator_activity_id, benchmark_indicator_id, benchmark_technical_area_id FROM plan_activities) SELECT json_agg(t) FROM t;
 ```

--- a/test/fixtures/files/plan_for_nigeria_jee1/plan_activities.json
+++ b/test/fixtures/files/plan_for_nigeria_jee1/plan_activities.json
@@ -1,942 +1,1412 @@
 [
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 1
+    "benchmark_indicator_activity_id": 1,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 2
+    "benchmark_indicator_activity_id": 2,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 3
+    "benchmark_indicator_activity_id": 3,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 4
+    "benchmark_indicator_activity_id": 4,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 5
+    "benchmark_indicator_activity_id": 5,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 6
+    "benchmark_indicator_activity_id": 6,
+    "benchmark_indicator_id": 1,
+    "benchmark_technical_area_id": 1
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 56
+    "benchmark_indicator_activity_id": 56,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 57
+    "benchmark_indicator_activity_id": 57,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 58
+    "benchmark_indicator_activity_id": 58,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 59
+    "benchmark_indicator_activity_id": 59,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 60
+    "benchmark_indicator_activity_id": 60,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 107
+    "benchmark_indicator_activity_id": 107,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 108
+    "benchmark_indicator_activity_id": 108,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 109
+    "benchmark_indicator_activity_id": 109,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 110
+    "benchmark_indicator_activity_id": 110,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 111
+    "benchmark_indicator_activity_id": 111,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 112
+    "benchmark_indicator_activity_id": 112,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 113
+    "benchmark_indicator_activity_id": 113,
+    "benchmark_indicator_id": 7,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 128
+    "benchmark_indicator_activity_id": 128,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 129
+    "benchmark_indicator_activity_id": 129,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 130
+    "benchmark_indicator_activity_id": 130,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 131
+    "benchmark_indicator_activity_id": 131,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 132
+    "benchmark_indicator_activity_id": 132,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 133
+    "benchmark_indicator_activity_id": 133,
+    "benchmark_indicator_id": 8,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 148
+    "benchmark_indicator_activity_id": 148,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 149
+    "benchmark_indicator_activity_id": 149,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 150
+    "benchmark_indicator_activity_id": 150,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 151
+    "benchmark_indicator_activity_id": 151,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 152
+    "benchmark_indicator_activity_id": 152,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 153
+    "benchmark_indicator_activity_id": 153,
+    "benchmark_indicator_id": 9,
+    "benchmark_technical_area_id": 3
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 176
+    "benchmark_indicator_activity_id": 176,
+    "benchmark_indicator_id": 10,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 177
+    "benchmark_indicator_activity_id": 177,
+    "benchmark_indicator_id": 10,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 178
+    "benchmark_indicator_activity_id": 178,
+    "benchmark_indicator_id": 10,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 179
+    "benchmark_indicator_activity_id": 179,
+    "benchmark_indicator_id": 10,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 507
+    "benchmark_indicator_activity_id": 507,
+    "benchmark_indicator_id": 26,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 508
+    "benchmark_indicator_activity_id": 508,
+    "benchmark_indicator_id": 26,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 509
+    "benchmark_indicator_activity_id": 509,
+    "benchmark_indicator_id": 26,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 510
+    "benchmark_indicator_activity_id": 510,
+    "benchmark_indicator_id": 26,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 511
+    "benchmark_indicator_activity_id": 511,
+    "benchmark_indicator_id": 26,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 188
+    "benchmark_indicator_activity_id": 188,
+    "benchmark_indicator_id": 11,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 189
+    "benchmark_indicator_activity_id": 189,
+    "benchmark_indicator_id": 11,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 190
+    "benchmark_indicator_activity_id": 190,
+    "benchmark_indicator_id": 11,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 191
+    "benchmark_indicator_activity_id": 191,
+    "benchmark_indicator_id": 11,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 192
+    "benchmark_indicator_activity_id": 192,
+    "benchmark_indicator_id": 11,
+    "benchmark_technical_area_id": 4
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 219
+    "benchmark_indicator_activity_id": 219,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 220
+    "benchmark_indicator_activity_id": 220,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 221
+    "benchmark_indicator_activity_id": 221,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 222
+    "benchmark_indicator_activity_id": 222,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 223
+    "benchmark_indicator_activity_id": 223,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 224
+    "benchmark_indicator_activity_id": 224,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 225
+    "benchmark_indicator_activity_id": 225,
+    "benchmark_indicator_id": 12,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 238
+    "benchmark_indicator_activity_id": 238,
+    "benchmark_indicator_id": 13,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 239
+    "benchmark_indicator_activity_id": 239,
+    "benchmark_indicator_id": 13,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 240
+    "benchmark_indicator_activity_id": 240,
+    "benchmark_indicator_id": 13,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 241
+    "benchmark_indicator_activity_id": 241,
+    "benchmark_indicator_id": 13,
+    "benchmark_technical_area_id": 5
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 370
+    "benchmark_indicator_activity_id": 370,
+    "benchmark_indicator_id": 20,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 371
+    "benchmark_indicator_activity_id": 371,
+    "benchmark_indicator_id": 20,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 372
+    "benchmark_indicator_activity_id": 372,
+    "benchmark_indicator_id": 20,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 373
+    "benchmark_indicator_activity_id": 373,
+    "benchmark_indicator_id": 20,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 374
+    "benchmark_indicator_activity_id": 374,
+    "benchmark_indicator_id": 20,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 393
+    "benchmark_indicator_activity_id": 393,
+    "benchmark_indicator_id": 21,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 394
+    "benchmark_indicator_activity_id": 394,
+    "benchmark_indicator_id": 21,
+    "benchmark_technical_area_id": 8
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 265
+    "benchmark_indicator_activity_id": 265,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 266
+    "benchmark_indicator_activity_id": 266,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 267
+    "benchmark_indicator_activity_id": 267,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 268
+    "benchmark_indicator_activity_id": 268,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 269
+    "benchmark_indicator_activity_id": 269,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 270
+    "benchmark_indicator_activity_id": 270,
+    "benchmark_indicator_id": 14,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 294
+    "benchmark_indicator_activity_id": 294,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 295
+    "benchmark_indicator_activity_id": 295,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 296
+    "benchmark_indicator_activity_id": 296,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 297
+    "benchmark_indicator_activity_id": 297,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 298
+    "benchmark_indicator_activity_id": 298,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 299
+    "benchmark_indicator_activity_id": 299,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 300
+    "benchmark_indicator_activity_id": 300,
+    "benchmark_indicator_id": 15,
+    "benchmark_technical_area_id": 6
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 317
+    "benchmark_indicator_activity_id": 317,
+    "benchmark_indicator_id": 16,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 318
+    "benchmark_indicator_activity_id": 318,
+    "benchmark_indicator_id": 16,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 319
+    "benchmark_indicator_activity_id": 319,
+    "benchmark_indicator_id": 16,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 320
+    "benchmark_indicator_activity_id": 320,
+    "benchmark_indicator_id": 16,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 321
+    "benchmark_indicator_activity_id": 321,
+    "benchmark_indicator_id": 16,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 324
+    "benchmark_indicator_activity_id": 324,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 325
+    "benchmark_indicator_activity_id": 325,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 326
+    "benchmark_indicator_activity_id": 326,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 327
+    "benchmark_indicator_activity_id": 327,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 328
+    "benchmark_indicator_activity_id": 328,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 329
+    "benchmark_indicator_activity_id": 329,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 330
+    "benchmark_indicator_activity_id": 330,
+    "benchmark_indicator_id": 17,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 348
+    "benchmark_indicator_activity_id": 348,
+    "benchmark_indicator_id": 18,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 349
+    "benchmark_indicator_activity_id": 349,
+    "benchmark_indicator_id": 18,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 350
+    "benchmark_indicator_activity_id": 350,
+    "benchmark_indicator_id": 18,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 361
+    "benchmark_indicator_activity_id": 361,
+    "benchmark_indicator_id": 19,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 362
+    "benchmark_indicator_activity_id": 362,
+    "benchmark_indicator_id": 19,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 363
+    "benchmark_indicator_activity_id": 363,
+    "benchmark_indicator_id": 19,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 364
+    "benchmark_indicator_activity_id": 364,
+    "benchmark_indicator_id": 19,
+    "benchmark_technical_area_id": 7
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 426
+    "benchmark_indicator_activity_id": 426,
+    "benchmark_indicator_id": 22,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 427
+    "benchmark_indicator_activity_id": 427,
+    "benchmark_indicator_id": 22,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 428
+    "benchmark_indicator_activity_id": 428,
+    "benchmark_indicator_id": 22,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 429
+    "benchmark_indicator_activity_id": 429,
+    "benchmark_indicator_id": 22,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 430
+    "benchmark_indicator_activity_id": 430,
+    "benchmark_indicator_id": 22,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 442
+    "benchmark_indicator_activity_id": 442,
+    "benchmark_indicator_id": 23,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 443
+    "benchmark_indicator_activity_id": 443,
+    "benchmark_indicator_id": 23,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 444
+    "benchmark_indicator_activity_id": 444,
+    "benchmark_indicator_id": 23,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 445
+    "benchmark_indicator_activity_id": 445,
+    "benchmark_indicator_id": 23,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 446
+    "benchmark_indicator_activity_id": 446,
+    "benchmark_indicator_id": 23,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 468
+    "benchmark_indicator_activity_id": 468,
+    "benchmark_indicator_id": 24,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 469
+    "benchmark_indicator_activity_id": 469,
+    "benchmark_indicator_id": 24,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 470
+    "benchmark_indicator_activity_id": 470,
+    "benchmark_indicator_id": 24,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 471
+    "benchmark_indicator_activity_id": 471,
+    "benchmark_indicator_id": 24,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 472
+    "benchmark_indicator_activity_id": 472,
+    "benchmark_indicator_id": 24,
+    "benchmark_technical_area_id": 9
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 61
+    "benchmark_indicator_activity_id": 61,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 62
+    "benchmark_indicator_activity_id": 62,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 63
+    "benchmark_indicator_activity_id": 63,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 64
+    "benchmark_indicator_activity_id": 64,
+    "benchmark_indicator_id": 4,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 72
+    "benchmark_indicator_activity_id": 72,
+    "benchmark_indicator_id": 5,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 73
+    "benchmark_indicator_activity_id": 73,
+    "benchmark_indicator_id": 5,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 74
+    "benchmark_indicator_activity_id": 74,
+    "benchmark_indicator_id": 5,
+    "benchmark_technical_area_id": 2
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 556
+    "benchmark_indicator_activity_id": 556,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 557
+    "benchmark_indicator_activity_id": 557,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 558
+    "benchmark_indicator_activity_id": 558,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 559
+    "benchmark_indicator_activity_id": 559,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 560
+    "benchmark_indicator_activity_id": 560,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 561
+    "benchmark_indicator_activity_id": 561,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 562
+    "benchmark_indicator_activity_id": 562,
+    "benchmark_indicator_id": 28,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 482
+    "benchmark_indicator_activity_id": 482,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 483
+    "benchmark_indicator_activity_id": 483,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 484
+    "benchmark_indicator_activity_id": 484,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 485
+    "benchmark_indicator_activity_id": 485,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 486
+    "benchmark_indicator_activity_id": 486,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 487
+    "benchmark_indicator_activity_id": 487,
+    "benchmark_indicator_id": 25,
+    "benchmark_technical_area_id": 10
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 585
+    "benchmark_indicator_activity_id": 585,
+    "benchmark_indicator_id": 30,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 586
+    "benchmark_indicator_activity_id": 586,
+    "benchmark_indicator_id": 30,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 587
+    "benchmark_indicator_activity_id": 587,
+    "benchmark_indicator_id": 30,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 588
+    "benchmark_indicator_activity_id": 588,
+    "benchmark_indicator_id": 30,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 589
+    "benchmark_indicator_activity_id": 589,
+    "benchmark_indicator_id": 30,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 563
+    "benchmark_indicator_activity_id": 563,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 564
+    "benchmark_indicator_activity_id": 564,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 565
+    "benchmark_indicator_activity_id": 565,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 566
+    "benchmark_indicator_activity_id": 566,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 567
+    "benchmark_indicator_activity_id": 567,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 568
+    "benchmark_indicator_activity_id": 568,
+    "benchmark_indicator_id": 29,
+    "benchmark_technical_area_id": 11
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 628
+    "benchmark_indicator_activity_id": 628,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 629
+    "benchmark_indicator_activity_id": 629,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 630
+    "benchmark_indicator_activity_id": 630,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 631
+    "benchmark_indicator_activity_id": 631,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 632
+    "benchmark_indicator_activity_id": 632,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 633
+    "benchmark_indicator_activity_id": 633,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 634
+    "benchmark_indicator_activity_id": 634,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 635
+    "benchmark_indicator_activity_id": 635,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 636
+    "benchmark_indicator_activity_id": 636,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 637
+    "benchmark_indicator_activity_id": 637,
+    "benchmark_indicator_id": 32,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 652
+    "benchmark_indicator_activity_id": 652,
+    "benchmark_indicator_id": 33,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 653
+    "benchmark_indicator_activity_id": 653,
+    "benchmark_indicator_id": 33,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 654
+    "benchmark_indicator_activity_id": 654,
+    "benchmark_indicator_id": 33,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 655
+    "benchmark_indicator_activity_id": 655,
+    "benchmark_indicator_id": 33,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 656
+    "benchmark_indicator_activity_id": 656,
+    "benchmark_indicator_id": 33,
+    "benchmark_technical_area_id": 12
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 725
+    "benchmark_indicator_activity_id": 725,
+    "benchmark_indicator_id": 37,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 726
+    "benchmark_indicator_activity_id": 726,
+    "benchmark_indicator_id": 37,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 727
+    "benchmark_indicator_activity_id": 727,
+    "benchmark_indicator_id": 37,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 661
+    "benchmark_indicator_activity_id": 661,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 662
+    "benchmark_indicator_activity_id": 662,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 663
+    "benchmark_indicator_activity_id": 663,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 664
+    "benchmark_indicator_activity_id": 664,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 665
+    "benchmark_indicator_activity_id": 665,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 666
+    "benchmark_indicator_activity_id": 666,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 667
+    "benchmark_indicator_activity_id": 667,
+    "benchmark_indicator_id": 34,
+    "benchmark_technical_area_id": 13
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 682
+    "benchmark_indicator_activity_id": 682,
+    "benchmark_indicator_id": 35,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 683
+    "benchmark_indicator_activity_id": 683,
+    "benchmark_indicator_id": 35,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 684
+    "benchmark_indicator_activity_id": 684,
+    "benchmark_indicator_id": 35,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 685
+    "benchmark_indicator_activity_id": 685,
+    "benchmark_indicator_id": 35,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 699
+    "benchmark_indicator_activity_id": 699,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 700
+    "benchmark_indicator_activity_id": 700,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 701
+    "benchmark_indicator_activity_id": 701,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 702
+    "benchmark_indicator_activity_id": 702,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 703
+    "benchmark_indicator_activity_id": 703,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 704
+    "benchmark_indicator_activity_id": 704,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 705
+    "benchmark_indicator_activity_id": 705,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 706
+    "benchmark_indicator_activity_id": 706,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 707
+    "benchmark_indicator_activity_id": 707,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 708
+    "benchmark_indicator_activity_id": 708,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 709
+    "benchmark_indicator_activity_id": 709,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 710
+    "benchmark_indicator_activity_id": 710,
+    "benchmark_indicator_id": 36,
+    "benchmark_technical_area_id": 14
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 733
+    "benchmark_indicator_activity_id": 733,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 734
+    "benchmark_indicator_activity_id": 734,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 735
+    "benchmark_indicator_activity_id": 735,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 736
+    "benchmark_indicator_activity_id": 736,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 737
+    "benchmark_indicator_activity_id": 737,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 738
+    "benchmark_indicator_activity_id": 738,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 762
+    "benchmark_indicator_activity_id": 762,
+    "benchmark_indicator_id": 39,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 763
+    "benchmark_indicator_activity_id": 763,
+    "benchmark_indicator_id": 39,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 764
+    "benchmark_indicator_activity_id": 764,
+    "benchmark_indicator_id": 39,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 765
+    "benchmark_indicator_activity_id": 765,
+    "benchmark_indicator_id": 39,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 739
+    "benchmark_indicator_activity_id": 739,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 740
+    "benchmark_indicator_activity_id": 740,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 741
+    "benchmark_indicator_activity_id": 741,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 742
+    "benchmark_indicator_activity_id": 742,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 743
+    "benchmark_indicator_activity_id": 743,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 744
+    "benchmark_indicator_activity_id": 744,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 745
+    "benchmark_indicator_activity_id": 745,
+    "benchmark_indicator_id": 38,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 780
+    "benchmark_indicator_activity_id": 780,
+    "benchmark_indicator_id": 40,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 781
+    "benchmark_indicator_activity_id": 781,
+    "benchmark_indicator_id": 40,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 782
+    "benchmark_indicator_activity_id": 782,
+    "benchmark_indicator_id": 40,
+    "benchmark_technical_area_id": 15
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 785
+    "benchmark_indicator_activity_id": 785,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 786
+    "benchmark_indicator_activity_id": 786,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 787
+    "benchmark_indicator_activity_id": 787,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 788
+    "benchmark_indicator_activity_id": 788,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 789
+    "benchmark_indicator_activity_id": 789,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 790
+    "benchmark_indicator_activity_id": 790,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 791
+    "benchmark_indicator_activity_id": 791,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 792
+    "benchmark_indicator_activity_id": 792,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 793
+    "benchmark_indicator_activity_id": 793,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 794
+    "benchmark_indicator_activity_id": 794,
+    "benchmark_indicator_id": 41,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 807
+    "benchmark_indicator_activity_id": 807,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 808
+    "benchmark_indicator_activity_id": 808,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 809
+    "benchmark_indicator_activity_id": 809,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 810
+    "benchmark_indicator_activity_id": 810,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 811
+    "benchmark_indicator_activity_id": 811,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 812
+    "benchmark_indicator_activity_id": 812,
+    "benchmark_indicator_id": 42,
+    "benchmark_technical_area_id": 16
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 827
+    "benchmark_indicator_activity_id": 827,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 828
+    "benchmark_indicator_activity_id": 828,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 829
+    "benchmark_indicator_activity_id": 829,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 830
+    "benchmark_indicator_activity_id": 830,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 831
+    "benchmark_indicator_activity_id": 831,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 832
+    "benchmark_indicator_activity_id": 832,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 833
+    "benchmark_indicator_activity_id": 833,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 834
+    "benchmark_indicator_activity_id": 834,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 835
+    "benchmark_indicator_activity_id": 835,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 836
+    "benchmark_indicator_activity_id": 836,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 837
+    "benchmark_indicator_activity_id": 837,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 838
+    "benchmark_indicator_activity_id": 838,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 839
+    "benchmark_indicator_activity_id": 839,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 840
+    "benchmark_indicator_activity_id": 840,
+    "benchmark_indicator_id": 43,
+    "benchmark_technical_area_id": 17
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 869
+    "benchmark_indicator_activity_id": 869,
+    "benchmark_indicator_id": 44,
+    "benchmark_technical_area_id": 18
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 870
+    "benchmark_indicator_activity_id": 870,
+    "benchmark_indicator_id": 44,
+    "benchmark_technical_area_id": 18
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 871
+    "benchmark_indicator_activity_id": 871,
+    "benchmark_indicator_id": 44,
+    "benchmark_technical_area_id": 18
   },
   {
     "plan_id": 1,
-    "benchmark_indicator_activity_id": 872
+    "benchmark_indicator_activity_id": 872,
+    "benchmark_indicator_id": 44,
+    "benchmark_technical_area_id": 18
   }
 ]

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -334,13 +334,48 @@ describe Plan do
   end
 
   describe "#count_activities_by_ta" do
-    let(:plan) { create(:plan_nigeria_jee1) }
+    describe "for a full plan" do
+      let(:benchmark_technical_areas) { BenchmarkTechnicalArea.all }
+      let(:plan) { create(:plan_nigeria_jee1) }
 
-    it "returns an array of the expected integers" do
-      expected = [6, 12, 19, 9, 11, 13, 19, 7, 15, 18, 11, 15, 7, 19, 20, 16, 14, 4]
-      plan.count_activities_by_ta.must_equal expected
+      it "returns an array of the expected integers" do
+        expected = [6, 12, 19, 9, 11, 13, 19, 7, 15, 18, 11, 15, 7, 19, 20, 16, 14, 4]
+        plan.count_activities_by_ta(benchmark_technical_areas).must_equal expected
+      end
+    end
+
+    describe "for a plan of sparsely populated technical areas" do
+      let(:benchmark_technical_areas) { BenchmarkTechnicalArea.all }
+      let(:indicator_attrs) do
+        {
+            jee1_ind_p21: "2",
+            jee1_ind_p21_goal: "3",
+            jee1_ind_d21: "3",
+            jee1_ind_d21_goal: "4",
+            jee1_ind_d22: "2",
+            jee1_ind_d22_goal: "3",
+            jee1_ind_d23: "3",
+            jee1_ind_d23_goal: "4",
+            jee1_ind_d24: "3",
+            jee1_ind_d24_goal: "4",
+        }.with_indifferent_access
+      end
+      let(:plan) do
+        Plan.create_from_goal_form(
+          indicator_attrs: indicator_attrs,
+          assessment: assessment_for_nigeria_jee1,
+          is_5_year_plan: true,
+          plan_name: "test plan 3737"
+        )
+      end
+
+      it "returns an array of the expected integers" do
+        expected = [0, 5, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        plan.count_activities_by_ta(benchmark_technical_areas).must_equal expected
+      end
     end
   end
+
 
   describe "#activities_for" do
     let(:plan) { create(:plan_nigeria_jee1) }


### PR DESCRIPTION
- Plan#create for JEE 1.0 1-year plan went from about 4 sec to about 2 sec. Plan#show for same went from about 6 sec to about 1 sec.
- gains PlanBuilder#create_from_goal_form are due to fixing what could be called a bug where the Plan.transaction was called more than once. Also from accessing IDs instead of loading the object
- gains on Plan#show are from putting more IDs on the plan_activities table and using those in the loops that connect together data
- modify plan#count_activities_by_ta to work in a more performant way, taking advantage of the schema change to tally the activity count with fewer hops across object associations
- on advise from the bullet gem made changes to better optimize queries for their uses by templates/etc, made use of custom scopes/finders
- add new class BenchmarkDocument to encapsulate Benchmarks and all its related data: technical areas, indicators, activities
- update the plan_activities.json file and its README per the schema changes
- there is a system test assertion failing for no apparent reason