### PR TITLE
[Web-Friendly WHO Benchmarks Doc] Create a layout for the Technical Area + Indicators page #169820453

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,12 +126,14 @@ h2 {
 h3 {
   font-size: 24px;
   line-height: 28px;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 
 h4 {
   font-size: 21px;
   line-height: 26px;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 

--- a/app/assets/stylesheets/benchmark-document.scss
+++ b/app/assets/stylesheets/benchmark-document.scss
@@ -8,6 +8,10 @@
       ul {
         li {
           margin: 0 0 0.5em 0;
+          ul {
+            list-style: none;
+            padding-left: 0;
+          }
         }
       }
       ol {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
  <div>
   <ul class="navbar-nav">
     <li class="nav-item"><%= link_to "HOME", root_path %></li>
-    <li class="nav-item"><%= link_to "WHO BENCHMARKS", benchmarks_intro_url %></li>
+    <li class="nav-item"><%= link_to "WHO BENCHMARKS", introduction_url %></li>
       <% if current_user %>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">

--- a/app/views/pages/_benchmark_document_navigation.html.haml
+++ b/app/views/pages/_benchmark_document_navigation.html.haml
@@ -5,14 +5,25 @@
   .card-body
     %ul.nav.flex-column
       %li
-        %a{href: "#"}
+        %a{href: introduction_path}
           Introduction
       %li
         Technical Areas
       %ol
         %li
-          %a{href: "#"}
+          %a{href: technical_area_1_path}
             National legislation, policy, and financing
+          - if request.path.eql?(technical_area_1_path)
+            %ul
+              %li
+                %a{href: "#{technical_area_1_path}#1.1"}
+                  Benchmark 1.1
+              %li
+                %a{href: "#{technical_area_1_path}#1.2"}
+                  Benchmark 1.2
+              %li
+                %a{href: "#{technical_area_1_path}#1.3"}
+                  Benchmark 1.3
         %li
           %a{href: "#"}
             IHR coordination, communication, and advocacy and reporting
@@ -70,7 +81,6 @@
       %li
         %a{href: "#"}
           Acknowledgement
-
 
 .card
   .card-header

--- a/app/views/pages/technical_area_1.html.haml
+++ b/app/views/pages/technical_area_1.html.haml
@@ -1,0 +1,292 @@
+= render layout: "layouts/benchmark_document" do
+
+  %h1
+    National Legislation, Policy and Financing
+
+  .callout-with-icon
+    %h3
+      Legislation and policy
+    An adequate legal framework for States Parties is essential to support and enable the implementation of all their obligations and rights of the IHR. This can include the creation of new legislation and/or the revision of existing legislation, regulations or other instruments to facilitate implementation and compliance with IHR (2005). A lack of appropriate legislation or policy can be a major barrier to implementation and should be considered a priority to enable other technical areas to be implemented effectively.
+  .callout-with-icon
+    %h3
+      Finance
+    States Parties should have the provision of adequate funding for IHR implementation through the national budget or other mechanisms. The country should have access to financial resources that can be accessed on time and distributed in response to public health emergencies for timely and adequate preparedness and response.
+  .callout-with-icon
+    %h3
+      Impact
+    Legislation and financing is in place in all relevant sectors to support IHR implementation including relevant core capacity development and maintenance.
+  .callout-with-icon
+    %h3
+      Monitoring and evaluation
+    (1) Current legislation including laws, regulations, administrative requirements, policies or other government instruments, proven to be adequate in all relevant sectors to support IHR implementation. (2) Adequate finances available to enable timely, efficient and effective IHR implementation and response to all public health emergencies.
+
+  %hr
+
+  %a{name: "1.1"}
+  .alert.alert-dark
+    Capacity Level
+  %p
+    %strong
+      Benchmark 1.1:
+    Domestic legislation, laws, regulations, policy and administrative requirements are available in all relevant sectors and effectively enable compliance with the IHR
+  %p
+    %strong
+      Objective:
+    To assess, adjust and align domestic legislation, laws, regulations, policy and administrative requirements in all relevant sectors to enable compliance with the IHR
+
+  .alert.alert-danger
+    01 No Capacity
+  %p
+    No assessment of relevant legislation, laws, regulations, policy and administrative requirements, and other government instruments for IHR implementation.
+
+  .alert.alert-warning
+    02 Limited Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Identify and convene key stakeholders related to the review, formulation and implementation of legislation and policies.
+      %li
+        Assess current relevant legislation, laws, regulations, policy and administrative requirements for IHR implementation and identify gaps, including for reporting, prevention and control.
+      %li
+        Develop an implementation plan for the formulation/revision/adjustment and approval of prioritized legislation/regulations and policy (including regulatory or parliamentary process based on the country's practices, as necessary).
+      %li
+        Develop advocacy materials and package to raise awareness of the requirements of adjustments to parliamentarians, government, oppositions and other relevant stakeholders.
+      %li
+        Develop an orientation package to implement the legislation, laws, regulations, policy and administrative requirements.
+      %li
+        Identify legislative/policy champion(s) or broker(s) who can advocate for the law or policy to reach a successful end state.
+
+  .alert.alert-warning
+    02 Developed Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Conduct an orientation with relevant stakeholders regarding adjustment in the legislation, laws, regulations, policy and administrative requirements.
+      %li
+        Develop a mechanism to implement these legislation, laws, regulations, policy and administrative requirements.
+      %li
+        Document the existence and use of appropriate legislation in all relevant sectors involved in IHR implementation.
+      %li
+        Develop or adjust the legislation, laws, regulations, policy and administrative requirements for implementation of IHR capacities for food safety, and if required for chemical safety.
+
+  .alert.alert-success
+    02 Demonstrated Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Review the use of relevant legislation, laws, regulations, policy and administrative requirements, and determine whether they cover most aspects of IHR implementation.
+      %li
+        Identify specific areas5 that require legislation references (these are reference laws or regulations that can support IHR implementation) such as establishing the IHR national focal point (NFP) or to mandate the operation.
+      %li
+        Develop or document legislation references for chemical safety and radiation emergency that contribute to chemical and radio-nuclear events preparedness, detection and response.
+      %li
+        Document these legislation references and relevant interpretations that can assist in IHR implementation.
+
+  .alert.alert-success
+    02 Sustainable Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Confirm that relevant legislation, laws, regulations, policy and administrative requirements cover all aspects of IHR implementation based on the risk profile of the country.
+      %li
+        Develop or document legislation references for any outstanding issues (including radiation emergencies) that contribute to preparedness, detection and response.
+      %li
+        Document these legislation references and relevant interpretations that can assist in IHR implementation.
+
+  %a{name: "1.2"}
+  .alert.alert-dark
+    Capacity Level
+  %p
+    %strong
+      Benchmark 1.2:
+    Financing is available for the implementation of IHR capacities
+  %p
+    %strong
+      Objective:
+    To assess, adjust and align domestic legislation, laws, regulations, policy and administrative requirements in all relevant sectors to enable compliance with the IHR
+
+  .alert.alert-danger
+    01 No Capacity
+  %p
+    No assessment of relevant legislation, laws, regulations, policy and administrative requirements, and other government instruments for IHR implementation.
+
+  .alert.alert-warning
+    02 Limited Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Identify and convene key stakeholders related to the review of financing for implementation of IHR capacities, including budgetary allocation and external contribution for the implementation of IHR capacities.
+      %li
+        Review the national action plan or any relevant plan for the implementation of IHR capacities (if not developed, follow guidelines and develop the national action plan).
+      %li
+        Review the cost estimates and currently available funds for the implementation of IHR capacities; if a costed plan is not available, then identify focal points of key stakeholders and develop the costing. If necessary, hire costing experts to estimate the cost of the plan working closely with key technical focal points of each technical area.
+      %li
+        Conduct a resource mapping on domestic and/or external funds for the implementation of IHR capacities.
+      %li
+        Allocate the budget, either domestic or external funds, to the relevant sectors and their respective ministries to support the implementation of IHR capacities for biological hazards at the national level.
+      %ul
+        %li
+          Develop the resource mobilization strategy and advocacy tools for the financing and identify key stakeholders.
+        %li
+          Develop a mechanism to lobby for domestic resources (both government and private sectors).
+
+  .alert.alert-warning
+    03 Developed Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Review resource mapping status to allocate budget rationally to every sector at the national level.
+      %li
+        Allocate available budget from domestic and external sources for human health, veterinary public health, agriculture, and all other relevant ministries or sectors, to support the implementation of all IHR capacities at the national level.
+      %li
+        Implement and review the use of available financing and its effectiveness.
+
+  .alert.alert-success
+    04 Demonstrated Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Review resource mapping status to rationally allocate budget to every sector at national and subnational levels.
+      %li
+        Allocate sufficient budget at national and subnational levels for the implementation of all IHR capacities in all relevant ministries or sectors.
+      %li
+        Monitor budget distribution and expenditure by all the relevant ministries at national and subnational levels.
+
+  .alert.alert-success
+    05 Sustainable Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Conduct regular meetings to review implementation of the allocated budget by all relevant ministries or sectors.
+      %li
+        Develop a tool to monitor that timely distribution and use of the budget are coordinated for activities and interventions to implement IHR capacities.
+      %li
+        Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors.
+
+  %a{name: "1.3"}
+  .alert.alert-dark
+    Capacity Level
+  %p
+    %strong
+      Benchmark 1.3:
+    Financing available for timely response to public health emergencies
+  %p
+    %strong
+      Objective:
+    To develop a financing mechanism to ensure that funds are available for timely response to public health emergencies
+
+  .alert.alert-danger
+    01 No Capacity
+  %p
+    %ul
+      %li
+        No mechanism of financing exists to respond to public health emergencies.
+      %li
+        Funds are allocated and distributed in an ad hoc manner from different sources during public health emergencies.
+
+  .alert.alert-warning
+    02 Limited Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Identify and convene key stakeholders to review the status of the emergency financing mechanism11 to respond to public health emergencies.
+      %li
+        Review the emergency public financing mechanism, particularly the acceptance and rapid distribution of funds to respond to public health emergencies.
+      %li
+        Conduct stakeholder analysis to identify domestic and external partners who can support mobilizing funds during emergencies, and, if necessary and appropriate, establish a memorandum of understanding with these stakeholders.
+      %li
+        Develop or revise the mechanism and structure to receive and rapidly distribute funds during emergencies. Conduct a simulation exercise or after-action review to assess functionality of the new finance policy or procedures. Document outcomes and make necessary changes to optimize procedure.
+
+  .alert.alert-warning
+    03 Developed Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Review and ensure functionality of the emergency public financing mechanism, particularly the mobilization of funds when needed at the national, state, provincial and regional levels for all relevant sectors.
+      %li
+        Develop and disseminate protocols or mechanisms for the timely execution of funds by all relevant sectors.
+      %li
+        Conduct a field test of the mechanism and update if necessary.
+      %li
+        Demonstrate and document that the funds are mobilized in advance of a public health emergency.
+
+  .alert.alert-success
+    04 Demonstrated Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Demonstrate that all relevant ministries have capacity to access and utilize the emergency public financing mechanism for early detection and response operations.
+      %li
+        Develop SOP's to support actors not usually involved with public sector services, such as nongovernmental organizations and the private sector to access emergency funds when needed
+      %li
+        Develop SOP's or MoU's that fast-track procurement and service agreements that can be activated during emergencies to expedite response.
+      %li
+        Develop accounting and reporting procedures for accountability and transparency of all emergency SOP and MOU's that will be used during emergency response.
+      %li
+        Review the effectiveness of emergency financing mechanism following any response to a public health emergencies and adjust procedures to ensure speed, transparency and accountability of all funds.
+
+  .alert.alert-success
+    05 Sustainable Capacity
+  %p
+    %strong
+      Actions to achieve this level:
+    %ul
+      %li
+        Establish an emergency contingency fund at the national level with the support of urgent response, and when required a national authority which can coordinate the receipt and distribution of funds to local and intermediate levels.
+      %li
+        Establish a link and/or memorandum of understanding with other regional or global emergency contingency funds, through which a national authority can coordinate and distribute funds.
+      %li
+        Establish a system for accountability of the distribution and use of these funds and publish information documenting transparency in expenditure and programme impacts towards protecting health.
+
+  %hr
+
+  %h3 Tools:
+  %ul
+    %li
+      Strengthening health security by implementing the International Health Regulations (2005) –
+      = succeed "." do
+        %a{href: "https://www.who.int/ihr/about/general_information/en/", target: "_blank"}
+          General Information
+    %li
+      %a{href: "http://apps.who.int/iris/bitstream/handle/10665/246107/9789241580496-eng.pdf", target: "_blank"}
+        International Health Regulations (2005). Third edition. Geneva: World Health Organization
+      ; 2016
+    %li
+      = succeed "." do
+        %a{href: "https://www.who.int/ihr/legal_issues/en/", target: "_blank"}
+          Support to national legislation for IHR implementation
+    %li
+      IHR (2005):
+      = succeed "." do
+        %a{href: "https://www.who.int/ihr/legal_issues/legislation/en/", target: "_blank"}
+          Guidance on implementation in national legislation
+    %li
+      = succeed "." do
+        %a{href: "https://extranet.who.int/sph/delivering-global-health-security-through-sustainable-financing", target: "_blank"}
+          Delivering global health security through sustainable financing
+      Geneva: World Health Organization; 2018
+    %li
+      %a{href: "https://www.who.int/emergencies/funding/en/", target: "_blank"}
+        Funding for emergencies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root to: "pages#home"
   get "/privacy_policy", to: "pages#privacy_policy"
-  get "/document/introduction", to: "pages#introduction", as: "benchmarks_intro"
+  get "/document/introduction", to: "pages#introduction", as: "introduction"
+  get "/document/1-national-legislation-policy-and-financing", to: "pages#technical_area_1", as: "technical_area_1"
   match "/get_started", to: "plans#get_started", via: [:get, :post]
   get "plan/goals/:country_name/:assessment_type(/:plan_term)(/:areas)", to: "plans#goals", as: "plan_goals"
   resources :plans, only: %i[show index create update destroy]

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -24,4 +24,27 @@ describe PagesController do
     end
   end
 
+  describe "benchmarks introduction page" do
+    it "is connected as the root URL" do
+      assert_routing("/document/introduction", {controller: "pages", action: "introduction"})
+    end
+
+    it "responds with success" do
+      get introduction_url
+      assert_response :success
+      assert_template "pages/introduction"
+    end
+  end
+
+  describe "benchmarks technical area page 1" do
+    it "is connected as the root URL" do
+      assert_routing("/document/1-national-legislation-policy-and-financing", {controller: "pages", action: "technical_area_1"})
+    end
+
+    it "responds with success" do
+      get technical_area_1_url
+      assert_response :success
+      assert_template "pages/technical_area_1"
+    end
+  end
 end


### PR DESCRIPTION
- this story is for structure, layout, and navigation. styling the content will be addressed in the next story
- add sub-sub-list in the nav for indicators underneath its technical area, and show them via server-side logic
- add view template app/views/pages/technical_area_1.html.haml and routing for it and tests