### PR TITLE
[Draft Plan]  Change Technical Area labels on Bar Chart to shorthand labels instead of B1, B2, etc. #171286067

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -230,22 +230,19 @@
     color: #545B62;
   }
 
-  #bar-chart-by-activity-type {
-    // needs more bottom margin to allow the angled labels to display w/o cutoff
-    .ct-chart-bar {
-      overflow: visible;
-      margin : 0 0 90px 0;
-    }
+  // labels for chart by activity type at 45º angle per design
+  .ct-label.ct-horizontal {
+    position: fixed; // makes the labels and their position scale/zoom well
+    justify-content: flex-end;
+    text-align: right;
+    transform-origin: right;
+    transform: translate(-45%) rotate(-45deg);
+    white-space: nowrap;
+  }
 
-    // labels for chart by activity type at 45º angle per design
-    .ct-label.ct-horizontal {
-      position: fixed; // makes the labels and their position scale/zoom well
-      justify-content: flex-end;
-      text-align: right;
-      transform-origin: right;
-      transform: translate(-45%) rotate(-45deg);
-      white-space: nowrap;
-    }
+  .ct-chart-bar {
+    // needs more bottom margin to allow the angled labels to display w/o cut off
+    margin : 0 0 50px 0;
   }
 }
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -95,7 +95,6 @@ class PlansController < ApplicationController
     @benchmark_technical_areas = benchmark_document.technical_areas
     @benchmark_indicators = benchmark_document.indicators
     @all_activities = benchmark_document.activities
-    @technical_area_abbrev_map = BenchmarkTechnicalArea.to_abbreviation_map(@benchmark_technical_areas)
     @nudges_by_activity_type_json = File.read(Rails.root.join("app", "fixtures", "nudges_for_activity_types.json"))
     @plan = Plan.deep_load(params.fetch(:id))
     @count_activities_by_ta = @plan.count_activities_by_ta(@benchmark_technical_areas)

--- a/app/javascript/src/controllers/plan_controller.js
+++ b/app/javascript/src/controllers/plan_controller.js
@@ -186,19 +186,19 @@ export default class extends Controller {
   }
 
   initClickHandlerForChartByTechnicalArea($elBarSegment, index) {
-    const chartLabels = this.chartLabels[this.currentChartIndex]
-    if (chartLabels[index]) {
+    if (index > 0) {
       $($elBarSegment).on('click', () => {
         $("#activity-list-by-type-container").hide()
         $('.technical-area-container').hide()
-        $('#technical-area-' + chartLabels[index]).show()
+        // NB: index is zero-based, but the target is 1-based, which is why +1.
+        $(`#technical-area-${index + 1}`).show()
       })
     }
   }
 
   initTooltipForSegmentOfChartByTechnicalArea($elBarSegment, index) {
-    const chartLabels = this.chartLabels[this.currentChartIndex]
-    let $elTitle = $('#technical-area-' + chartLabels[index])
+    // NB: index is zero-based, but the target is 1-based, which is why +1.
+    let $elTitle = $(`#technical-area-${index + 1}`)
     let tooltipTitle = $elTitle.attr("title") + ": " + $elBarSegment.attr("ct:value")
     $elBarSegment
         .attr("title", tooltipTitle)

--- a/app/models/benchmark_technical_area.rb
+++ b/app/models/benchmark_technical_area.rb
@@ -5,19 +5,6 @@ class BenchmarkTechnicalArea < ApplicationRecord
 
   default_scope { order(:sequence) }
 
-  def self.to_abbreviation_map(benchmark_technical_areas = nil)
-    abbreviation_map = {}
-    technical_areas = benchmark_technical_areas.blank? ? all: benchmark_technical_areas
-    technical_areas.each do |bta|
-      abbreviation_map[bta.to_abbreviation] = bta.id
-    end
-    abbreviation_map
-  end
-
-  def to_abbreviation
-    "B#{sequence}"
-  end
-
   def attributes
     {
         id: nil,

--- a/app/views/plans/_plan_name_sticky.html.erb
+++ b/app/views/plans/_plan_name_sticky.html.erb
@@ -2,7 +2,7 @@
 
   <div class="col-11 mx-auto row justify-content-between">
 
-    <div class="col-2">
+    <div class="col-auto">
       <div style="height: 60px;">
         <div class="form-group alt-header" style="min-width: 200px;">
           <%= form.text_field :name, data: { target: "plan.name", action: "change->plan#validateName" }, class: "form-control", required: true %>
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <div class="col-2">
+    <div class="col-auto">
       <div style="min-width: 140px;">
         <%= submit_tag "Save Plan", data: { target: "plan.submit", action: "plan#saveActivityIdsToField"}, class: "btn btn-orange w-100 align-self-center" %>
       </div>

--- a/app/views/plans/_technical_area.html.erb
+++ b/app/views/plans/_technical_area.html.erb
@@ -1,15 +1,13 @@
 <div class="technical-area-container"
-     id="technical-area-<%= chart_label %>"
+     id="technical-area-<%= benchmark_technical_area.sequence %>"
      title="<%= benchmark_technical_area.text %>"
      data-technical-area-id="<%= benchmark_technical_area.id %>"
      data-target="plan.technicalAreaContainer"
 >
-  <%# unless @plan.from_technical_areas? %>
-    <h3 id="<%= benchmark_technical_area.text.parameterize %>">
-      <%= benchmark_technical_area.sequence %>.
-      <%= benchmark_technical_area.text %>
-    </h3>
-  <%# end %>
+  <h3>
+    <%= benchmark_technical_area.sequence %>.
+    <%= benchmark_technical_area.text %>
+  </h3>
 
   <% benchmark_technical_area.benchmark_indicators.each do |benchmark_indicator| %>
     <%= render 'benchmark_indicator',

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,4 +1,23 @@
-<% chart_labels_by_technical_area = @technical_area_abbrev_map.keys %>
+<% chart_labels_by_technical_area = [
+    "Legislation",
+    "IHR coordination",
+    "AMR",
+    "Zoonotic disease",
+    "Food safety",
+    "Immunization",
+    "Laboratory",
+    "Biosafety & biosecurity",
+    "Surveillance",
+    "Human resources",
+    "Preparedness",
+    "Rapid response",
+    "Linking public health",
+    "Medical countermeasures",
+    "Risk communication",
+    "Points of entry",
+    "Chemical events",
+    "Radiation",
+] %>
 
 <div class="row">
 

--- a/test/fixtures/for_js_tests/plan_show_page_with_two_technical_areas.html
+++ b/test/fixtures/for_js_tests/plan_show_page_with_two_technical_areas.html
@@ -9,7 +9,7 @@
                          data-plan-nudge-content-selectors='["#nudge-for-technical-area-1-year", "#nudge-for-technical-area-5-year"]'
                          data-plan-nudge-template-selector="#nudge-template"
                          data-plan-chart-selectors='["#bar-chart-by-technical-area", "#bar-chart-by-activity-type"]'
-                         data-plan-chart-labels='[["B1","B2","B3","B4","B5","B6","B7","B8","B9","B10","B11","B12","B13","B14","B15","B16","B17","B18"],["Advocacy","Assessment and Data Use","Coordination","Designation","Dissemination","Financing","Monitoring and Evaluation","Planning and Strategy","Procurement","Program Implementation","SimEx and AAR","SOPs","Surveillance","Tool Development","Training"]]'
+                         data-plan-chart-labels='[["Legislation","IHR coordination","AMR","Zoonotic disease","Food safety","Immunization","Laboratory","Biosafety & biosecurity","Surveillance","Human resources","Preparedness","Rapid response","Linking public health","Medical countermeasures","Risk communication","Points of entry","Chemical events","Radiation"],["Advocacy","Assessment and Data Use","Coordination","Designation","Dissemination","Financing","Monitoring and Evaluation","Planning and Strategy","Procurement","Program Implementation","SimEx and AAR","SOPs","Surveillance","Tool Development","Training"]]'
                          data-plan-chart-series='[[6,12,19,9,11,13,19,7,15,18,11,15,7,19,20,16,14,4],[8,40,23,7,9,9,20,45,2,45,13,32,8,3,23]]'
                          data-plan-chart-width="710"
                          data-plan-chart-height="240">

--- a/test/helpers/pages_helper_test.rb
+++ b/test/helpers/pages_helper_test.rb
@@ -10,11 +10,11 @@ class PagesHelperTest < ActionView::TestCase
   end
 
   test "#technical_area_to_id handles arg not in the collection" do
-    assert_equal nil, technical_area_to_id(technical_areas, "asd123")
+    assert_nil technical_area_to_id(technical_areas, "asd123")
   end
 
   test "#technical_area_to_id handles nil" do
-    assert_equal nil, technical_area_to_id(technical_areas, nil)
+    assert_nil technical_area_to_id(technical_areas, nil)
   end
 
 end

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -41,8 +41,8 @@ class AppsTest < ApplicationSystemTestCase
     assert_equal "Nigeria draft plan", find("#plan_name").value
     assert page.has_content?("TOTAL ACTIVITIES")
     assert_equal "235", find(".activity-count-circle span").text
-    assert_selector("#technical-area-B1") # the first one
-    assert_selector("#technical-area-B18") # the last one
+    assert_selector("#technical-area-1") # the first one
+    assert_selector("#technical-area-18") # the last one
     assert_selector(".nudge-container") do
       assert page.has_content?( # nudge content for 1-year plan
         "Focus on no more than 2-3 activities per technical area"
@@ -51,13 +51,13 @@ class AppsTest < ApplicationSystemTestCase
 
     # verify bar chart by technical area filter functionality
     find('line[data-original-title*="Radiation Emerg"]').click
-    assert_selector("#technical-area-B18") # the last one
-    assert_no_selector("#technical-area-B1") # the first one
+    assert_selector("#technical-area-18") # the last one
+    assert_no_selector("#technical-area-1") # the first one
 
     # un-filter to show all
     find(".activity-count-circle").click
-    assert_selector("#technical-area-B1")
-    assert_selector("#technical-area-B18")
+    assert_selector("#technical-area-1")
+    assert_selector("#technical-area-18")
 
     # edit the plan name and hit save button
     find("#plan_name").fill_in with: "Saved Nigeria Plan 789"


### PR DESCRIPTION
- re-work the chart segments tooltip get their value to now use sequence of the TechnicalArea instead of the text, using +1 to account for zero/one-based differences
- modify and simplify the CSS for putting the chart labels at an angle since it now applied to both charts
- remove @technical_area_abbrev_map from the controller since no longer needed
- remove methods BenchmarkTechnicalArea.to_abbreviation_map and .to_abbreviation since no longer used anywhere
- tweak to the _plan_name_sticky.html.erb partial to get the form's text input field to display the full length, it was truncated
- modify pages_helper_test.rb to use assert_nil since I was seeing a warning message about how I was doing it previous to this change
- update some tests and a test fixture per these changes