### PR TITLE
[Draft Plan Page] Make input & button in header standard size #171505802

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -228,8 +228,8 @@ a.cta-btn {
   font-family: Karla, sans-serif;
   text-transform: uppercase;
   input {
-    font-size: 30px;
-    line-height: 30px;
+    font-size: 22px;
+    line-height: 22px;
     color: $dark;
   }
 }

--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -257,6 +257,16 @@
   }
 }
 
+.stick-to-top {
+  input.plan-name {
+    height: 38px;
+  }
+  input.plan-save {
+    height: 38px;
+    min-width: 140px;
+  }
+}
+
 .plan-container {
   .tooltip.bs-tooltip-top .arrow:before {
     border-top-color: color("gray-dark-transparent");

--- a/app/views/plans/_plan_name_sticky.html.erb
+++ b/app/views/plans/_plan_name_sticky.html.erb
@@ -2,15 +2,15 @@
 
   <div class="container mx-auto row no-gutters justify-content-between p-2">
 
-    <div class="col-auto m-2 form-group alt-header" style="height: 60px; min-width: 200px;">
-      <%= form.text_field :name, data: { target: "plan.name", action: "change->plan#validateName" }, class: "form-control", required: true %>
+    <div class="col-lg-5 m-2 form-group alt-header">
+      <%= form.text_field :name, data: { target: "plan.name", action: "change->plan#validateName" }, class: "plan-name form-control", required: true %>
       <div class="invalid-feedback">
         Cannot be empty
       </div>
     </div>
 
-    <div class="col-auto m-2" style="min-width: 140px;">
-      <%= submit_tag "Save Plan", data: { target: "plan.submit", action: "plan#saveActivityIdsToField"}, class: "btn btn-orange w-100" %>
+    <div class="col-auto m-2">
+      <%= submit_tag "Save Plan", data: { target: "plan.submit", action: "plan#saveActivityIdsToField"}, class: "plan-save btn btn-orange w-100" %>
     </div>
 
   </div>


### PR DESCRIPTION
- change styles for the text field and save button in the navy blue sticky bar per Stacy's revised designs which take up less screen space. make the text field wider, and scale to full width below lg.