### PR TITLE
[Header Nav] Line logo up to grid, space out nav items #171505845

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -183,16 +183,20 @@ td {
 }
 
 nav.navbar {
-  min-height: 110px;
-  .nav-item {
+  min-height: max-content; // this is needed to prevent smaller screen sizes heights from collapsing
+  ul.navbar-nav {
+    text-align: right;
+  }
+  li.nav-item {
     letter-spacing: 0.1em;
     white-space: nowrap;
+    &:last-child a.nav-link {
+      padding-right: 0; // this is for the last A tag on the right to align with the edge of the page container
+    }
   }
   a.nav-link {
-    color: white;
+    color: white !important;
     text-decoration: none;
-    padding: 0;
-    text-align: right;
   }
 }
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,44 +1,54 @@
-<nav class="navbar navbar-expand-lg text-white bg-blue justify-content-between px-4">
+<nav class="navbar navbar-expand-lg navbar-dark bg-blue">
 
-  <a class="navbar-brand" href="https://extranet.who.int/sph/country-planning" target="_blank">
-    <%= image_tag("who-logo.svg", alt: "WHO Logo") %>
-  </a>
+  <div class="container">
 
-  <ul class="navbar-nav">
-    <li class="nav-item">
-      <a class="nav-link" href="<%= root_path %>">
-        HOME
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="<%= introduction_url %>">
-        WHO BENCHMARKS
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="<%= resource_library_url %>">
-        RESOURCE LIBRARY
-      </a>
-    </li>
-    <% if current_user %>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-          <%= current_user.email %>
-          <span><%= image_tag("down-caret.svg", alt: "Down Caret") %></span>
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <%= link_to "My Plans", plans_path, class: "dropdown-item" %>
-          <div class="dropdown-divider"></div>
-          <%= link_to "Log Out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
-        </div>
-      </li>
-    <% else %>
-      <li class="nav-item">
-        <a class="nav-link" href="<%= new_user_session_path %>">
-          LOG IN
-        </a>
-      </li>
-    <% end %>
-  </ul>
+    <a class="navbar-brand" href="https://extranet.who.int/sph/country-planning" target="_blank">
+      <%= image_tag("who-logo.svg", alt: "WHO Logo") %>
+    </a>
+
+    <button class="navbar-toggler text-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse justify-content-end" id="navbarTogglerDemo02">
+      <ul class="navbar-nav">
+        <li class="nav-item mx-lg-2">
+          <a class="nav-link py-1" href="<%= root_path %>">
+            HOME
+          </a>
+        </li>
+        <li class="nav-item mx-lg-2">
+          <a class="nav-link py-1" href="<%= introduction_url %>">
+            WHO BENCHMARKS
+          </a>
+        </li>
+        <li class="nav-item mx-lg-2">
+          <a class="nav-link py-1" href="<%= resource_library_url %>">
+            RESOURCE LIBRARY
+          </a>
+        </li>
+        <% if current_user %>
+          <li class="nav-item dropdown ml-lg-2">
+            <a class="nav-link py-1 dropdown-toggle" id="navbarDropdownMenuLink" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+              <%= current_user.email %>
+              <span><%= image_tag("down-caret.svg", alt: "Down Caret") %></span>
+            </a>
+            <div class="dropdown-menu dropdown-menu-lg-right" aria-labelledby="navbarDropdownMenuLink">
+              <%= link_to "My Plans", plans_path, class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
+              <%= link_to "Log Out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
+            </div>
+          </li>
+        <% else %>
+          <li class="nav-item ml-lg-2">
+            <a class="nav-link py-1" href="<%= new_user_session_path %>">
+              LOG IN
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+  </div>
 
 </nav>

--- a/app/views/layouts/_home_page_footer.html.erb
+++ b/app/views/layouts/_home_page_footer.html.erb
@@ -1,58 +1,60 @@
-<footer class="pt-4">
-  <div class="bg-dark-blue pt-4">
-    <div class="row p-0 m-0">
-      <div class="col ml-5">
-        <div class="row">
-          <div class="col">
-            <%= content_tag :span, "About", class: "heading" %>
+<footer class="bg-dark-blue pt-4">
+
+    <div class="container">
+      <div class="row no-gutters">
+        <div class="col">
+          <div class="row">
+            <div class="col">
+              <%= content_tag :span, "About", class: "heading" %>
+            </div>
+          </div>
+          <div class="row pt-4">
+            <div class="col">
+              <span>This tool is designed to accelerate the planning process for National Action Plans for Health Security within the International Health Regulations (IHR) Monitoring and Evaluation Framework.</span>
+            </div>
           </div>
         </div>
-        <div class="row pt-4">
-          <div class="col">
-            <span>This tool is designed to accelerate the planning process for National Action Plans for Health Security within the International Health Regulations (IHR) Monitoring and Evaluation Framework.</span>
+        <div class="col">
+          <div class="row">
+            <div class="col">
+              <%= content_tag :span, "For Reference", class: "heading" %>
+            </div>
+          </div>
+          <div class="row pt-4">
+            <div class="col">
+              <ul class="list-unstyled p-0">
+                <li><%= link_to "JEE 1.0", "https://www.who.int/ihr/publications/WHO_HSE_GCR_2016_2/en/", class: "text-white", target: "_blank" %></li>
+                <li><%= link_to "JEE 2.0", "https://www.who.int/ihr/publications/WHO_HSE_GCR_2018_2/en/", class: "text-white", target: "_blank" %></li>
+                <li><%= link_to "e-SPAR", "https://extranet.who.int/e-spar", class: "text-white", target: "_blank" %></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="row">
+            <div class="col">
+              <%= content_tag :span, "Contact", class: "heading" %>
+            </div>
+          </div>
+          <div class="row pt-4">
+            <div class="col">
+              <ul class="list-unstyled p-0">
+                <li><%= mail_to "sla@resolvetosavelives.org", "Report an Error" %></li>
+                <li><%= link_to "Privacy Policy", privacy_policy_path %></li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
-      <div class="col">
-        <div class="row">
-          <div class="col">
-            <%= content_tag :span, "For Reference", class: "heading" %>
-          </div>
-        </div>
-        <div class="row pt-4">
-          <div class="col">
-            <ul class="list-unstyled p-0">
-              <li><%= link_to "JEE 1.0", "https://www.who.int/ihr/publications/WHO_HSE_GCR_2016_2/en/", class: "text-white", target: "_blank" %></li>
-              <li><%= link_to "JEE 2.0", "https://www.who.int/ihr/publications/WHO_HSE_GCR_2018_2/en/", class: "text-white", target: "_blank" %></li>
-              <li><%= link_to "e-SPAR", "https://extranet.who.int/e-spar", class: "text-white", target: "_blank" %></li>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="col">
-        <div class="row">
-          <div class="col">
-            <%= content_tag :span, "Contact", class: "heading" %>
-          </div>
-        </div>
-        <div class="row pt-4">
-          <div class="col">
-            <ul class="list-unstyled p-0">
-              <li><%= mail_to "sla@resolvetosavelives.org", "Report an Error" %></li>
-              <li><%= link_to "Privacy Policy", privacy_policy_path %></li>
-            </ul>
-          </div>
+      <div class="row pt-5">
+        <div class="col text-center">
+          <%= link_to image_tag(image_path("prevent-epidemics-logo.svg")), "https://preventepidemics.org", target: "_blank", class: "footer-logo" %>
+          <!-- <%= link_to image_tag(image_path("rtsl-logo.svg")), "https://www.resolvetosavelives.org", target: "_blank", class: "footer-logo" %> -->
+          <!-- <%= link_to image_tag(image_path("world-bank.svg")), "https://www.worldbank.org/", target: "_blank", class: "footer-logo"  %> -->
+          <!-- <%= link_to image_tag(image_path("cdc.svg")), "https://www.cdc.gov", target: "_blank", class: "footer-logo" %> -->
+          <%= content_tag :p, "© #{Date.today.year}. World Health Organization. All rights reserved.", class: "py-3 copyright" %>
         </div>
       </div>
     </div>
-    <div class="row pt-5">
-      <div class="col text-center">
-        <%= link_to image_tag(image_path("prevent-epidemics-logo.svg")), "https://preventepidemics.org", target: "_blank", class: "footer-logo" %>
-        <!-- <%= link_to image_tag(image_path("rtsl-logo.svg")), "https://www.resolvetosavelives.org", target: "_blank", class: "footer-logo" %> -->
-        <!-- <%= link_to image_tag(image_path("world-bank.svg")), "https://www.worldbank.org/", target: "_blank", class: "footer-logo"  %> -->
-        <!-- <%= link_to image_tag(image_path("cdc.svg")), "https://www.cdc.gov", target: "_blank", class: "footer-logo" %> -->
-        <%= content_tag :p, "© #{Date.today.year}. World Health Organization. All rights reserved.", class: "py-3 copyright" %>
-      </div>
-    </div>
-  </div>
+
 </footer>


### PR DESCRIPTION
- make the header nav align with the newly re-aligned page margins, via add div.container which constrains to the desired width
- allow the navigation menu links to stack at smaller sizes via use of bootstrap navbar and toggle and related classes: UL horizontal for lg screens, and for smaller screens it stacks and collapses along with the toggler button. dropdown still works.
- add more space along the sides (x-axis) of the links/a/li with more margins per Stacy
- have less space along the y-axis of the links/a/li so that when they stack for smaller screens its more compact
- tweaked footer to also align with recent overhaul of overall page margins, also simplified where possible