### PR TITLE
[171365497] IE compatible Resource Library

### DIFF
--- a/app/assets/stylesheets/ie.scss
+++ b/app/assets/stylesheets/ie.scss
@@ -31,3 +31,7 @@ nav.navbar {
   flex-shrink: 0;
   flex-basis: auto;
 }
+
+.col {
+  flex: 1 1 auto;
+}


### PR DESCRIPTION
as described here, in IE11 flex-basis should be explicitly set when
using flex-direction: column; 

https://makandracards.com/makandra/54644-do-not-use-flex-1-or-flex-basis-0-inside-flex-direction-column-when-you-need-to-support-ie11

# Stories
https://www.pivotaltracker.com/story/show/171365497

