### PR TITLE
[170568796] Bug: When activity added, it also appears at the end of the page

### DIFF
--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -27,3 +27,14 @@ ul.ui-autocomplete {
     }
   }
 }
+
+// this ensures that this helper is still available on screen readers: https://a11yproject.com/posts/how-to-hide-content/
+.ui-helper-hidden-accessible {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap; /* added line */
+}


### PR DESCRIPTION
The Jquery autocomplete widget displays helper text while navigation for screen readers' benefit. This is unfortunately not documented in their API, so this required some digging around. The fix is completely style based, and ensures that this text does not show up on a browser, but can be read from a screen reader.

# Stories
https://www.pivotaltracker.com/story/show/170568796

