### PR TITLE
[#171721472] [Let's get started] Bug: Goes to scores page before clicking "next"

### DIFF
--- a/app/javascript/src/controllers/get_started_controller.js
+++ b/app/javascript/src/controllers/get_started_controller.js
@@ -39,6 +39,9 @@ export default class extends Controller {
   }
 
   presubmitFormToLoadOtherFields() {
+    const countryValue = this.countrySelectTarget.value
+    this.formTarget.reset()
+    this.countrySelectTarget.value = countryValue
     window.submittedGetStartedAtLeastOnce = true
     $(this.formTarget).submit()
   }

--- a/app/javascript/src/controllers/get_started_controller.js
+++ b/app/javascript/src/controllers/get_started_controller.js
@@ -39,9 +39,12 @@ export default class extends Controller {
   }
 
   presubmitFormToLoadOtherFields() {
+    // the following reset/set flow is done to fix
+    // the bug reported here: https://www.pivotaltracker.com/story/show/171721472
     const countryValue = this.countrySelectTarget.value
     this.formTarget.reset()
     this.countrySelectTarget.value = countryValue
+
     window.submittedGetStartedAtLeastOnce = true
     $(this.formTarget).submit()
   }

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -19,6 +19,11 @@ class AppsTest < ApplicationSystemTestCase
     select_from_chosen("Nigeria", from: "get_started_form_country_id")
     choose "Joint External Evaluation (JEE)"
     choose "1 year plan"
+    select_from_chosen("Angola", from: "get_started_form_country_id")
+    assert_current_path("/get-started")
+    select_from_chosen('Nigeria', from: 'get_started_form_country_id')
+    choose "Joint External Evaluation (JEE)"
+    choose "1 year plan"
     click_on("Next")
 
     ##

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -19,9 +19,13 @@ class AppsTest < ApplicationSystemTestCase
     select_from_chosen("Nigeria", from: "get_started_form_country_id")
     choose "Joint External Evaluation (JEE)"
     choose "1 year plan"
+
+    # the following selection + assertion is done to verify fix of the
+    # the bug reported here: https://www.pivotaltracker.com/story/show/171721472
     select_from_chosen("Angola", from: "get_started_form_country_id")
     assert_current_path("/get-started")
-    select_from_chosen('Nigeria', from: 'get_started_form_country_id')
+
+    select_from_chosen("Nigeria", from: "get_started_form_country_id")
     choose "Joint External Evaluation (JEE)"
     choose "1 year plan"
     click_on("Next")


### PR DESCRIPTION
Ensure that the "Get started" form is reset whenever a country is selected. 

A "valid" (all values present) submission to the `get_started` action causes a redirect. The solution is to ensure that assessment and plan selection is reset (and therefore not set) when a country is selected.

# Stories

#171721472

