### PR TITLE
IE compatible Benchmarks doc page #171365469

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,3 +27,6 @@ Turbolinks.start()
 const application = Application.start()
 const context = require.context("../src/controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))
+
+// fix for IE Benchmarks doc page Monitoring icon too small/out of alignment #171365469
+$(".benchmark-document .callout-with-icon svg.bar-chart path").attr("transform", "scale(2)");


### PR DESCRIPTION
- add JS to set the transform property because IE does not support SVG transforms via CSS. does not change rendering of modern browsers.