### PR TITLE
fix extra space preceding superscripts

### DIFF
--- a/app/views/pages/introduction.html.haml
+++ b/app/views/pages/introduction.html.haml
@@ -13,10 +13,8 @@
     Purpose of the benchmark tool
   %p
     This document guides States Parties, partners, donors and international and national organizations on suggested actions needed to improve IHR capacities for health security. States Parties and other entities
-    working to reduce the risk of global health threats can use these benchmarks and suggested actions to address gaps, including those identified by IHR monitoring and evaluation framework
-    %sup
-      %a{href: "#1"}
-        1 
+    working to reduce the risk of global health threats can use these benchmarks and suggested actions to address gaps, including those identified by IHR monitoring and evaluation
+    = raw 'framework<sup><a href="#1">1</a></sup>'
     components such as the States Party self-assessment annual reporting tool, voluntary external evaluation such as the joint external evaluation (JEE), after-action reviews and simulation exercises. This document can help countries delineate the relevant steps they can take to reach capacity levels as defined in each benchmark.
 
   %h3
@@ -41,15 +39,11 @@
     Following the recommendation of the IHR review committee on second extensions for establishing national public health capacities and on IHR Implementation, the WHO Secretariat developed the IHR monitoring and evaluation framework and through global consultations developed monitoring and evaluation tools such as the new IHR States Parties self-assessment
     annual reporting tool (SPAR) and the JEE.
 
-    In May 2018, as per the decision of the Seventy-first World Health Assembly decision on the implementation of the IHR five-year global strategic plan to improve public health preparedness and response, 2018–2023,
-    %sup
-      %a{href: "#2"}
-        2 
+    In May 2018, as per the decision of the Seventy-first World Health Assembly decision on the implementation of the IHR five-year global strategic plan to improve public health preparedness and response,
+    = raw '2018–2023,<sup><a href="#2">2</a></sup>'
     the WHO Secretariat commenced to develop the benchmark tool with suggested actions at each capacity level for the technical areas or capacities that
-    can capture the outcome of the different monitoring and evaluation processes (such as the SPAR and the JEE), which inform the development of national action plans for health security.
-    %sup
-      %a{href: "#3"}
-        3 
+    can capture the outcome of the different monitoring and evaluation processes (such as the SPAR and the JEE), which inform the development of national action plans for health
+    = raw 'security.<sup><a href="#3">3</a></sup>'
     These suggested actions can provide guidance to develop activities to build capacity needed to move from one capacity level to the next; stepping up from level 1 to 2, and 2 to 3 and beyond.
   %h3
     Structure of the tool
@@ -89,10 +83,8 @@
   %h4
     When to use the benchmark tool?
   %p
-    The tool should be used during the planning process when a planning team is identifying and prioritizing activities for the various steps of the NAPHS framework.
-    %sup
-      %a{href: "#4"}
-        4
+    The tool should be used during the planning process when a planning team is identifying and prioritizing activities for the various steps of the NAPHS
+    = raw 'framework.<sup><a href="#4">4</a></sup>'
   %h4
     How to use the benchmark tool?
   %p

--- a/app/views/pages/technical_area_1.html.haml
+++ b/app/views/pages/technical_area_1.html.haml
@@ -108,10 +108,8 @@
         %li
           Review the use of relevant legislation, laws, regulations, policy and administrative requirements, and determine whether they cover most aspects of IHR implementation.
         %li
-          = precede "Identify specific areas" do
-            %sup
-              %a{href: "#5"}
-                5
+          Identify specific
+          = raw 'areas<sup><a href="#5">5</a></sup>'
           that require legislation references (these are reference laws or regulations that can support IHR implementation) such as establishing the IHR national focal point (NFP) or to mandate the operation.
         %li
           Develop or document legislation references for chemical safety and radiation emergency that contribute to chemical and radio-nuclear events preparedness, detection and response.
@@ -140,10 +138,7 @@
   .indicator-head
     %h3
       Benchmark 1.2:
-    Financing
-    %sup
-      %a{href: "#6"}
-        6
+    = raw 'Financing<sup><a href="#6">6</a></sup>'
     is available for the implementation of IHR capacities
   %p
     %strong
@@ -157,14 +152,10 @@
       .level-desc
         No capacity
     .body.col-9
-      No budget line or budgetary allocation
-      %sup
-        %a{href: "#7"}
-          7
-      available to finance the implementation of IHR capacities, and financing is handled through extrabudgetary means.
-      %sup
-        %a{href: "#8"}
-          8
+      No budget line or budgetary
+      = raw 'allocation<sup><a href="#7">7</a></sup>'
+      available to finance the implementation of IHR capacities, and financing is handled through extrabudgetary
+      = raw 'means.<sup><a href="#8">8</a></sup>'
 
   .indicator-capacity-row
     .head.col.bg-warning
@@ -222,10 +213,8 @@
         %li
           Review resource mapping status to rationally allocate budget to every sector at national and subnational levels.
         %li
-          Allocate sufficient
-          %sup
-            %a{href: "#9"}
-              9
+          Allocate
+          = raw 'sufficient<sup><a href="#9">9</a></sup>'
           budget at national and subnational levels for the implementation of all IHR capacities in all relevant ministries or sectors.
         %li
           Monitor budget distribution and expenditure by all the relevant ministries at national and subnational levels.
@@ -252,10 +241,8 @@
   .indicator-head
     %h3
       Benchmark 1.3:
-    Financing available for timely response to public health emergencies
-    %sup
-      %a{href: "#10"}
-        10
+    Financing available for timely response to public health
+    = raw 'emergencies<sup><a href="#10">10</a></sup>'
   %p
     %strong
       Objective:
@@ -285,10 +272,8 @@
         Actions to achieve this level:
       %ul
         %li
-          Identify and convene key stakeholders to review the status of the emergency financing mechanism
-          %sup
-            %a{href: "#11"}
-              11
+          Identify and convene key stakeholders to review the status of the emergency financing
+          = raw 'mechanism<sup><a href="#11">11</a></sup>'
           to respond to public health emergencies.
         %li
           Review the emergency public financing mechanism, particularly the acceptance and rapid distribution of funds to respond to public health emergencies.
@@ -310,10 +295,8 @@
         %li
           Review and ensure functionality of the emergency public financing mechanism, particularly the mobilization of funds when needed at the national, state, provincial and regional levels for all relevant sectors.
         %li
-          Develop and disseminate protocols or mechanisms for the timely execution
-        %sup
-          %a{href: "#12"}
-            12
+          Develop and disseminate protocols or mechanisms for the timely
+          = raw 'execution<sup><a href="#12">12</a></sup>'
           of funds by all relevant sectors.
         %li
           Conduct a field test of the mechanism and update if necessary.

--- a/app/views/pages/technical_area_10.html.haml
+++ b/app/views/pages/technical_area_10.html.haml
@@ -55,16 +55,11 @@
       %strong
         Actions to achieve this level:
       %ul
-        %li 
-          Assess
-          %sup
-            %a{href: "#45"}
-              45
-          and develop/document
-          %sup
-            %a{href: "#46"}
-              46
-          country’s current health workforce strategy. 
+        %li
+          = raw 'Assess<sup><a href="#45">45</a></sup>'
+          and
+          = raw 'develop/document<sup><a href="#46">46</a></sup>'
+          country’s current health workforce strategy.
         %li 
           Build planning capacity to develop or improve human resources for health policy and strategies that quantify health workforce needs, demands and supply under varied future scenarios. 
         %li 

--- a/app/views/pages/technical_area_11.html.haml
+++ b/app/views/pages/technical_area_11.html.haml
@@ -4,11 +4,9 @@
     11. Emergency preparedness
   
   %p
-    State Parties are in “emergency preparedness.”
-    %sup
-      %a{href: "#47"}
-        47
-    Strategic risk assessment identifies, analyses and evaluates the range of risks in a country and enables the risks to be assigned a level of priority. It includes analyses of potential hazards exposures and vulnerabilities, identification and mapping of available resources, and analyses of capacities (routine and surge) at the national, intermediate and local or primary levels to manage the risks of outbreaks and other emergencies. Emergency preparedness applies to any hazard that may cause an emergency and includes biological, chemical, radiological and nuclear, natural, other technological and societal hazards. 
+    State Parties are in “emergency
+    =raw 'preparedness.”<sup><a href="#47">47</a>'
+    Strategic risk assessment identifies, analyses and evaluates the range of risks in a country and enables the risks to be assigned a level of priority. It includes analyses of potential hazards exposures and vulnerabilities, identification and mapping of available resources, and analyses of capacities (routine and surge) at the national, intermediate and local or primary levels to manage the risks of outbreaks and other emergencies. Emergency preparedness applies to any hazard that may cause an emergency and includes biological, chemical, radiological and nuclear, natural, other technological and societal hazards.
     
   .callout-with-icon
     .col-1.mx-auto.px-0

--- a/app/views/pages/technical_area_17.html.haml
+++ b/app/views/pages/technical_area_17.html.haml
@@ -60,11 +60,9 @@
         %li 
           Identify key stakeholders in all sectors and establish focal points for coordination and collaboration for chemical event surveillance, alert and response.
         %li 
-          Identify and describe priority chemical events
-          %sup
-            %a{href: "#49"}
-              49
-          to inform planning, a process which can include conducting an inventory of potentially hazardous chemical sites and manufacturing facilities and a review of past chemical events. 
+          Identify and describe priority chemical
+        = raw 'events<sup><a href="#49">49</a></sup>'
+          to inform planning, a process which can include conducting an inventory of potentially hazardous chemical sites and manufacturing facilities and a review of past chemical events.
         %li 
           Assess capacities for chemical event surveillance, alert and response at all levels (national, subnational).
         %li 
@@ -108,10 +106,8 @@
         %li 
           Provide adequate resources to the national 
           %a{href: "http://apps.who.int/iris/bitstream/10665/41966/1/9241544872_eng.pdf", target: "_blank"}
-            poison information service
-          %a{href: "#50"}
-            %sup
-              50
+            poison information
+            = raw 'service<sup><a href="#50">50</a></sup>'
           to operate on a 24/7 basis, and integrate the poisons information service into the public health surveillance system.
         %li 
           Put in place agreements with designated quality assured laboratories (national or laboratories in other countries) for timely analysis of biological and environmental samples with suspected chemical exposure.
@@ -127,10 +123,8 @@
         Actions to achieve this level:
       %ul
         %li 
-          Establish links with key international chemical/toxicology networks
-          %a{href: "#51"}
-            %sup
-              51
+          Establish links with key international chemical/toxicology
+          = raw ' networks<sup><a href="#51">51</a></sup>'
           for support in the management of chemical events and poisonings.
         %li 
           Ensure all relevant personnel receive regular training on surveillance, alert and response to chemical events and poisonings.
@@ -158,10 +152,8 @@
         %li 
           Develop a mechanism to integrate the systems of public health surveillance and environmental monitoring that captures and assesses chemical exposures from different sources. 
         %li 
-          Sustain a mechanism to ensure response capacity
-          %a{href: "#52"}
-            %sup
-              52
+          Sustain a mechanism to ensure response
+          = raw 'capacity<sup><a href="#52">52</a></sup>'
           at national, subnational and local levels.
  
   %h3 Tools:  

--- a/app/views/pages/technical_area_5.html.haml
+++ b/app/views/pages/technical_area_5.html.haml
@@ -64,10 +64,8 @@
         %li
           Link surveillance activities with the surveillance technical area benchmarks.
         %li
-          Develop guidelines and SOPs for the detection of foodborne events and implement indicator-/event-based disease surveillance (refer to indicator-/event-based disease surveillance columns for respective benchmarks).
-          %sup
-            %a{href: "#13"}
-              13
+          Develop guidelines and SOPs for the detection of foodborne events and implement indicator-/event-based disease surveillance (refer to indicator-/event-based disease surveillance columns for respective
+          = raw ' benchmarks).<sup><a href="#13">13</a></sup>'
         %li
           Develop and disseminate a training package on these guidelines and SOPs.
       %strong
@@ -113,18 +111,11 @@
         %li
           Test for foodborne diseases and/or contamination for the cases or events detected through indicator- or event-based disease surveillance to assign aetiology.
         %li
-          Develop or adopt the risk assessment protocol of acute foodborne events (chemical and microbiological).
-          %sup
-            %a{href: "#14"}
-              14
+          Develop or adopt the risk assessment protocol of acute foodborne events (chemical and
+          = raw 'microbiological).<sup><a href="#14">14</a></sup>'
         %li
-          Develop an information-sharing protocol and mechanism that will apply to all relevant stakeholders involved in foodborne disease surveillance and food contamination monitoring.
-          %sup
-            %a{href: "#22"}
-              22
-            ,
-            %a{href: "#15"}
-              15
+          Develop an information-sharing protocol and mechanism that will apply to all relevant stakeholders involved in foodborne disease surveillance and food contamination
+          = raw 'monitoring.<sup><a href="#22">22</a>, <a href="15">15</a></sup>'
 
   .indicator-capacity-row
     .col.head.bg-success
@@ -141,26 +132,13 @@
         %li
           Allocate or identify resources for such training and risk assessments. 
         %li
-          Conduct risk assessments of acute foodborne events (chemical and microbiological) and publish a periodic report (such as an epidemiological bulletin).
-          %sup
-            %a{href: "#16"}
-              16
-            ,
-            %a{href: "#17"}
-              17
-            ,
-            %a{href: "#18"}
-              18
-            ,
-            %a{href: "#19"}
-              19
+          Conduct risk assessments of acute foodborne events (chemical and microbiological) and publish a periodic report (such as an epidemiological
+          = raw ' bulletin).<sup><a href="#16">16</a>, <a href="#17">17</a>, <a href="#18">18</a>, <a href="#19">19</a></sup>'
         %li
           Train identified foodborne disease surveillance and food contamination monitoring focal points in the surveillance of such hazards.
         %li
-          Conduct a Total Diet Study or similar study and implement outcomes to complement the existing national monitoring and surveillance strategy.
-          %sup
-            %a{href: "#20"}
-              20
+          Conduct a Total Diet Study or similar study and implement outcomes to complement the existing national monitoring and surveillance
+        = raw 'strategy.<sup><a href="#20">20</a></sup>'
 
   .indicator-capacity-row
     .head.col.bg-success
@@ -210,31 +188,16 @@
         Actions to achieve this level:
       %ul
         %li
-          Review the mechanism, if it exists, for the response and management of food safety emergencies to identify and assess gaps and needs, with reference to relevant Food and Agriculture Organization (FAO)/WHO guidelines.
-          %sup
-            %a{href: "#21"}
-              21
-            ,
-            %a{href: "#22"}
-              22
-            ,
-            %a{href: "#23"}
-              23
-            ,
-            %a{href: "#24"}
-              24
+          Review the mechanism, if it exists, for the response and management of food safety emergencies to identify and assess gaps and needs, with reference to relevant Food and Agriculture Organization (FAO)/WHO
+          = raw 'guidelines.<sup><a href="#21">21</a>, <a href="#22">22</a>, <a href="#23">23</a>, <a href="#24">24</a></sup>'
         %li
           Identify key government agencies involved in the response and management of food safety emergencies.
         %li
-          Develop SOPs and guidelines for the response and management of food safety emergencies (These guidelines should be part of the overall surveillance guideline for foodborne diseases and contamination).
-          %sup
-            %a{href: "#25"}
-              25
+          Develop SOPs and guidelines for the response and management of food safety emergencies (These guidelines should be part of the overall surveillance guideline for foodborne diseases and
+          = raw 'contamination).<sup><a href="#25">25</a></sup>'
         %li
-          Designate an INFOSAN Emergency Contact Point in the government agency responsible for the response and management of food safety emergencies.
-          %sup
-            %a{href: "#26"}
-              26
+          Designate an INFOSAN Emergency Contact Point in the government agency responsible for the response and management of food safety
+          = raw 'emergencies.<sup><a href="#26">26</a></sup>'
 
   .indicator-capacity-row
     .head.col.bg-warning
@@ -266,15 +229,11 @@
         Actions to achieve this level:
       %ul
         %li
-          Develop strategies and guidance to communicate with partners, stakeholders, general public, international organizations and applicable regional and international networks, and orient them on these strategies and guidance.
-          %sup
-            %a{href: "#27"}
-              27
+          Develop strategies and guidance to communicate with partners, stakeholders, general public, international organizations and applicable regional and international networks, and orient them on these strategies and
+          = raw 'guidance.<sup><a href="#27">27</a></sup>'
         %li
-          Develop and disseminate risk communication messages to the public, through appropriate media, during food safety emergencies.
-          %sup
-            %a{href: "#28"}
-              28
+          Develop and disseminate risk communication messages to the public, through appropriate media, during food safety
+          = raw 'emergencies.<sup><a href="#28">28</a></sup>'
         %li
           •	Establish information sharing mechanisms at regional and international levels.
         %li

--- a/app/views/pages/technical_area_7.html.haml
+++ b/app/views/pages/technical_area_7.html.haml
@@ -4,10 +4,8 @@
     7. National Laboratory System
   
   %p
-    Surveillance with a national laboratory system,
-    %sup
-      %a{href: "#29"}
-        29
+    Surveillance with a national laboratory
+    = raw 'system,<sup><a href="#29">29</a></sup>'
     including all relevant sectors, particularly in human and animal (domestic animals and wildlife) health, and effective modern point-of-care and laboratory-based diagnostics is in place.
     
   .callout-with-icon
@@ -23,10 +21,8 @@
     .col
       %h3
         Monitoring and evaluation
-      (1) A nationwide laboratory system able to reliably conduct tests
-      %sup
-        %a{href: "#30"}
-        30
+      (1) A nationwide laboratory system able to reliably conduct
+      = raw 'tests<sup><a href="#30">30</a></sup>'
       at least for priority diseases of the country on appropriately identified and collected, and suspected or confirmed outbreak specimens transported safely and securely to accredited laboratories from at least 80% of intermediate levels/districts in the country. (2) Existence of national quality laboratory standards and system for licensing laboratories.
 
   %hr.indicator-hr
@@ -173,10 +169,8 @@
         Actions to achieve this level:
       %ul
         %li 
-          Review existing specimen referral and transportation networks for priority diseases, map existing laboratory capacity for priority diseases,
-          %sup
-            %a{href: "#31"}
-            31
+          Review existing specimen referral and transportation networks for priority diseases, map existing laboratory capacity for priority
+          = raw 'diseases,<sup><a href="#31">31</a></sup>'
           and establish referral networks for each pathogen.
         %li 
           Convene human and animal health sectors and other stakeholders to assess referral mechanisms and linkages among various levels of health facilities, including international networks with guidance and tools for dissemination.

--- a/app/views/pages/technical_area_8.html.haml
+++ b/app/views/pages/technical_area_8.html.haml
@@ -4,26 +4,16 @@
     8. Biosafety and biosecurity
   
   %p
-    A whole-of-government multisectoral national biosafety
-    %sup
-      %a{href: "#32"}
-        32
-    and biosecurity
-    %sup
-      %a{href: "#33"}
-        33
-    system with dangerous pathogens
-    %sup
-      %a{href: "#34"}
-        34
-    identified, held, secured and monitored in a minimal number of facilities according to best practices;
-    %sup
-      %a{href: "#35"}
-        35
-    biological risk management training and educational outreach conducted to promote a shared culture of responsibility,
-    %sup
-      %a{href: "#36"}
-        36
+    A whole-of-government multisectoral national
+    = raw 'biosafety<sup><a href="#32">32</a></sup>'
+    and
+    = raw 'biosecurity<sup><a href="#33">33</a></sup>'
+    system with dangerous
+    = raw 'pathogens<sup><a href="#34">34</a></sup>'
+    identified, held, secured and monitored in a minimal number of facilities according to best
+    = raw 'practices;<sup><a href="#35">35</a></sup>'
+    biological risk management training and educational outreach conducted to promote a shared culture of
+    = raw 'responsibility,<sup><a href="#36">36</a></sup>'
     reduce dual-use risks, mitigate biological proliferation and ensure safe transfer of biological agents; and country-specific biosafety and biosecurity legislation, laboratory licensing and pathogen control measures in place as appropriate.
     
   .callout-with-icon
@@ -32,10 +22,8 @@
     .col
       %h3
         Impact
-      Implementation of a comprehensive, sustainable and legally embedded national oversight programme for biosafety and biosecurity, including the safe and secure use, storage, disposal and containment of pathogens found in laboratories and a minimal number of holdings across the country, and involving research, diagnostic and biotechnology facilities within all sectors.
-      %sup
-        %a{href: "#37"}
-          37      
+      Implementation of a comprehensive, sustainable and legally embedded national oversight programme for biosafety and biosecurity, including the safe and secure use, storage, disposal and containment of pathogens found in laboratories and a minimal number of holdings across the country, and involving research, diagnostic and biotechnology facilities within all
+      = raw 'sectors.<sup><a href="#37">37</a></sup>'
       Strengthened, sustainable biological risk management best practices are in place using common educational materials. Safe and compliant transport of infectious substances is also considered according to national and international regulations.
 
   .callout-with-icon
@@ -133,7 +121,7 @@
           Develop documents for dual-use research and responsible code of conduct for scientists and staff.
         %li 
           Develop and implement an incident reporting system that includes identifying incidents, reporting according to regulations, and addressing action items that improve safety and security.
-        %li 
+        %li
           Establish external monitoring and oversight of biosafety and biosecurity practices.
         %li 
           Develop and implement equipment operation and maintenance plans at laboratories storing pathogens of security concern.

--- a/app/views/pages/technical_area_9.html.haml
+++ b/app/views/pages/technical_area_9.html.haml
@@ -4,14 +4,10 @@
     9. Surveillance
   
   %p
-    Strengthened surveillance  
-    %sup
-      %a{href: "#38"}
-        38
-    systems are able to detect events of significance for public health and health security; improve communication and collaboration across sectors and between subnational (local and intermediate), national and international levels of authority regarding surveillance of events of public health significance; and improve national and intermediate level regional capacity to analyse and link data from and between, strengthened early-warning surveillance, including interoperable,
-    %sup
-      %a{href: "#39"}
-        39
+    Strengthened
+    = raw 'surveillance<sup><a href="#38">38</a></sup>'
+    systems are able to detect events of significance for public health and health security; improve communication and collaboration across sectors and between subnational (local and intermediate), national and international levels of authority regarding surveillance of events of public health significance; and improve national and intermediate level regional capacity to analyse and link data from and between, strengthened early-warning surveillance, including
+    = raw 'interoperable,<sup><a href="#39">39</a></sup>'
     interconnected electronic tools. This would incorporate epidemiological, clinical, laboratory, environmental testing, product safety and quality, and bioinformatics data; and advances in fulfilling core capacity requirements for surveillance in accordance with the IHR and OIE guidelines.
     
   .callout-with-icon
@@ -20,18 +16,12 @@
     .col
       %h3
         Impact
-      (1) A functioning public health surveillance system
-      %sup
-        %a{href: "#40"}
-          40
-      capable of identifying potential events of concern for public health and health security.
-      %sup
-        %a{href: "#41"}
-          41
-      (2) Enhanced national and intermediate level regional capacity to analyse and link data from and between the different levels of the strengthened early-warning surveillance system.
-      %sup
-        %a{href: "#42"}
-          42
+      (1) A functioning public health surveillance
+      = raw 'system<sup><a href="#40">40</a></sup>'
+      capable of identifying potential events of concern for public health and health
+      = raw 'security.<sup><a href="#41">41</a></sup>'
+      (2) Enhanced national and intermediate level regional capacity to analyse and link data from and between the different levels of the strengthened early-warning surveillance
+      = raw 'system.<sup><a href="#42">42</a></sup>'
 
   .callout-with-icon
     .col-1.mx-auto.px-0
@@ -39,10 +29,8 @@
     .col
       %h3
         Monitoring and evaluation
-      (1) Surveillance for at least three core syndromes
-      %sup
-        %a{href: "#43"}
-          43
+      (1) Surveillance for at least three core
+      = raw 'syndromes<sup><a href="#43">43</a></sup>'
       indicative of potential public health emergencies conducted according to international standards. (2) Regular analysis and reporting of surveillance data.
 
   %hr.indicator-hr


### PR DESCRIPTION
[#171197263]

Replace all %sup tags with `= raw '<sup><a href="#<n>"><n></a></sup>'` which gets rid of any preceding space. Did not have to do this in the footer section of each page since the %sup tags are at the beginning of each line.