### PR TITLE
Fix the CTA button background color on Safari by setting -webkit-appearance: none

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -226,6 +226,7 @@ nav.navbar {
 }
 
 a.cta-btn {
+  -webkit-appearance: none; // This is so the background-color works on Safari
   height: 4.5em !important;
   line-height: 4.5em;
   padding: 0;


### PR DESCRIPTION
[#172852827]

The background-color property is ignored on Safari unless you set -webkit-appearance: none