### PR TITLE
Add to Get Started page a section for disease-specific planning for influenza, and pass the param through

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -33,15 +33,14 @@ class PlansController < ApplicationController
     if request.post? && request.xhr?
       if @get_started_form.valid?
         url =
-          plan_goals_url(
-            country_name: @get_started_form.country.name,
-            assessment_type: @get_started_form.assessment_type,
-            plan_term: @get_started_form.plan_term_s,
-            areas: @get_started_form.technical_area_ids.join("-"),
-          )
-        Rails.logger.info "Redirect workaround for an XHR request to URL: #{
-                            url
-                          }"
+            plan_goals_url(
+                country_name: @get_started_form.country.name,
+                assessment_type: @get_started_form.assessment_type,
+                plan_term: @get_started_form.plan_term_s,
+                areas: @get_started_form.technical_area_ids.present? ? @get_started_form.technical_area_ids.join("-") : nil,
+                diseases: @get_started_form.diseases.present? ? @get_started_form.diseases.join("-") : nil,
+            )
+        Rails.logger.info "Redirect workaround for an XHR request to URL: #{url}"
         render plain: "#{GET_STARTED_REDIRECT_KEY}#{url}"
         return
       else
@@ -58,6 +57,7 @@ class PlansController < ApplicationController
     assessment_type = params[:assessment_type]
     country_name = params[:country_name]
     technical_area_ids = params[:areas].to_s.split("-")
+    diseases = params[:diseases].to_s.split("-")
     country = Country.find_by_name country_name
     @publication = AssessmentPublication.find_by_named_id assessment_type
     if country.present? && @publication.present?

--- a/app/lib/get_started_form.rb
+++ b/app/lib/get_started_form.rb
@@ -5,27 +5,33 @@ class GetStartedForm
   attr_accessor :country_id,
                 :assessment_type,
                 :plan_by_technical_ids,
-                :plan_term
+                :plan_term,
+                :diseases
   attr_writer :technical_area_ids
   # object instances that should result from the inputs
-  attr_accessor :country, :assessment
+  attr_accessor :country, :assessment, :diseases
 
   validates :country, :assessment, presence: true
   validates :plan_term, inclusion: [1, 5] # in years
+  validate :valid_diseases?
 
   def initialize(attrs = {})
     super attrs
     init_technical_area_ids
+    init_diseases
     numeric_plan_term
     set_country
     set_assessment
   end
 
   def init_technical_area_ids
-    # when blank, initialize to an array
     @technical_area_ids = [] if @technical_area_ids.blank?
-    # when any values, convert them from string to integer
     @technical_area_ids = @technical_area_ids.map(&:to_i)
+  end
+
+  def init_diseases
+    @diseases = [] if @diseases.blank?
+    @diseases = @diseases.map(&:to_i)
   end
 
   def plan_by_technical_ids?
@@ -69,5 +75,9 @@ class GetStartedForm
   # return IDs only when the corresponding checkbox is selected
   def technical_area_ids
     plan_by_technical_ids? ? @technical_area_ids : []
+  end
+
+  def valid_diseases?
+    errors.add(:diseases, "Invalid disease id") unless diseases.empty? || diseases.all? { |disease| Plan::DISEASE_TYPES.include?(disease) }
   end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -10,6 +10,9 @@ class Plan < ApplicationRecord
   # TODO: update this implementation once the assessments page is modernized
   ASSESSMENT_TYPE_NAMED_IDS = %w[jee1 spar_2018 from-technical-areas].freeze
   TERM_TYPES = [100, 500] # 100 is 1-year, 500 is 5-year
+  DISEASE_TYPES = [
+      10, # influenza
+  ].freeze
   include PlanBuilder
 
   belongs_to :assessment

--- a/app/views/plans/get_started.html.haml
+++ b/app/views/plans/get_started.html.haml
@@ -102,6 +102,19 @@
             %div{style: "height: 75px"}
 
       .form-row
+        .col
+          %h4{class: heading_disabled_class} 4. Do you want to add disease specific planning?
+          - if @get_started_form.country.present?
+            .form-check
+              = check_box_tag "get_started_form[diseases][]", Plan::DISEASE_TYPES.first, false,
+                {class: "form-check-inline",
+                  id: "diseases_influenza"}
+              %label{for: "diseases_influenza"}
+                Optional: Influenza planning
+          - else
+            %div{style: "height: 75px"}
+
+      .form-row
         .col-2
           = form.submit "Next",
             class: "btn btn-primary",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "pages#home"
   match "/get-started", to: "plans#get_started", via: [:get, :post]
-  get "plan/goals/:country_name/:assessment_type(/:plan_term)(/:areas)", to: "plans#goals", as: "plan_goals"
+  get "plan/goals/:country_name/:assessment_type(/:plan_term)", to: "plans#goals", as: "plan_goals"
   resources :plans, only: %i[show index create update destroy]
   resources :worksheets, only: %i[show]
   resources :costsheets, only: %i[show]

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -59,6 +59,34 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    describe "with an ajax request with valid params diseases" do
+      it "responds with success containing the redirect key" do
+        post get_started_url,
+             xhr: true,
+             params: {
+                 get_started_form: {
+                     country_id: "162", assessment_type: "jee1", plan_term: "1", diseases: [10]
+                 },
+             }
+        assert_response :success
+        assert_template nil
+        response_body = response.body
+        response_body.starts_with?(
+            PlansController::GET_STARTED_REDIRECT_KEY,
+        ).must_equal true
+        redirect_url =
+            plan_goals_url(
+                {
+                    country_name: "Nigeria",
+                    assessment_type: "jee1",
+                    plan_term: "1-year",
+                    diseases: "10",
+                },
+            )
+        response_body.end_with?(redirect_url).must_equal true
+      end
+    end
+
     describe "#goals" do
       describe "for a non-existent assessment" do
         it "responds with success" do

--- a/test/lib/get_started_form_test.rb
+++ b/test/lib/get_started_form_test.rb
@@ -24,6 +24,28 @@ describe GetStartedForm do
     }
   end
 
+  let(:attrs_for_nigeria_jee1_5yr_influenza) do
+    {
+      # all string values so as to repro how received from an ActionController
+      country_id: "162",
+      # 162 is Nigeria
+      assessment_type: "jee1",
+      plan_term: "5",
+      diseases: [Plan::DISEASE_TYPES.first]
+    }
+  end
+
+  let(:attrs_for_nigeria_jee1_5yr_bad_disease) do
+    {
+       # all string values so as to repro how received from an ActionController
+       country_id: "162",
+       # 162 is Nigeria
+       assessment_type: "jee1",
+       plan_term: "5",
+       diseases: [0]
+    }
+  end
+
   describe "#initialize" do
     describe "for empty" do
       let(:subject) { GetStartedForm.new }
@@ -37,6 +59,13 @@ describe GetStartedForm do
           country
           assessment
         ].each { |mth| subject.send(mth).must_be_nil }
+      end
+
+      it "returns [] for members" do
+        %i[
+          technical_area_ids
+          diseases
+        ].each { |mth| subject.send(mth).must_equal [] }
       end
     end
 
@@ -97,6 +126,38 @@ describe GetStartedForm do
     end
   end
 
+  describe "for Nigeria JEE1 5-year plan with influenza" do
+    let(:subject) { GetStartedForm.new(attrs_for_nigeria_jee1_5yr_influenza) }
+
+    it "returns an the expected value for country_id" do
+      subject.country_id.must_equal "162"
+    end
+
+    it "returns an the expected value for assessment_type" do
+      subject.assessment_type.must_equal "jee1"
+    end
+
+    it "returns an the expected value for plan_by_technical_ids" do
+      subject.plan_by_technical_ids.must_be_nil
+    end
+
+    it "returns an the expected value for plan_term" do
+      subject.plan_term.must_equal 5
+    end
+
+    it "returns a country instance" do
+      subject.country.must_be_instance_of Country
+    end
+
+    it "returns an assessment instance" do
+      subject.assessment.must_be_instance_of Assessment
+    end
+
+    it "returns an expected value for diseases" do
+      subject.diseases.must_equal [Plan::DISEASE_TYPES.first]
+    end
+  end
+
   describe "#technical_area_ids" do
     let(:subject) { GetStartedForm.new(attrs_for_nigeria_jee1_2areas) }
 
@@ -150,6 +211,20 @@ describe GetStartedForm do
       it "has errors on plan_term" do
         subject.valid?.must_equal false
         subject.errors.include?(:plan_term).must_equal true
+      end
+
+      it "has no errors on optional diseases" do
+        subject.valid?.must_equal false
+        subject.errors.include?(:diseases).must_equal false
+      end
+    end
+
+    describe "with invalid disease" do
+      let (:subject) {GetStartedForm.new(attrs_for_nigeria_jee1_5yr_bad_disease)}
+
+      it "has errors" do
+        subject.valid?.must_equal false
+        subject.errors.include?(:diseases).must_equal true
       end
     end
 

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -184,7 +184,7 @@ class AppsTest < ApplicationSystemTestCase
 
     ##
     # turn up on the plan goal-setting page
-    assert_current_path("/plan/goals/Nigeria/jee1/5-year/2-9")
+    assert_current_path("/plan/goals/Nigeria/jee1/5-year?areas=2-9")
     assert page.has_content?("JEE SCORES")
     assert page.has_content?(
              "P.2.1 A functional mechanism is established for the coordination and integration of relevant sectors in the implementation of IHR",


### PR DESCRIPTION
[#172949058]

Note: both areas and and diseases are now query params since they can both be optional.

I also left in this line of code in PlansController#goals as a hint for the next story that follows this one
diseases = params[:diseases].to_s.split("-")