### PR TITLE
Minor improvement/simplifications of the Redux selectors

### DIFF
--- a/app/javascript/src/components/list/Action.js
+++ b/app/javascript/src/components/list/Action.js
@@ -1,12 +1,13 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { deleteAnAction } from "../../config/actions"
+import { getIndicatorMap } from "../../config/selectors"
 import { useSelector, useDispatch } from "react-redux"
 
 const Action = (props) => {
   const id = props.id
   const dispatch = useDispatch()
-  const indicatorMap = useSelector((state) => state.indicatorMap)
+  const indicatorMap = useSelector((state) => getIndicatorMap(state))
   const actionMap = useSelector((state) => state.actions)
   const action = actionMap[id]
   const indicator = indicatorMap[action.benchmark_indicator_id]

--- a/app/javascript/src/components/list/IndicatorActionList.js
+++ b/app/javascript/src/components/list/IndicatorActionList.js
@@ -1,13 +1,14 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { useSelector } from "react-redux"
+import { getPlanGoalMap } from "../../config/selectors"
 import Action from "./Action"
 import NoGoalForThisIndicator from "./NoGoalForThisIndicator"
 import AddAction from "./AddAction"
 
 const IndicatorActionList = (props) => {
   const indicator = props.indicator
-  const planGoalMap = useSelector((state) => state.planGoalMap)
+  const planGoalMap = useSelector((state) => getPlanGoalMap(state))
   const goalForThisIndicator = planGoalMap[indicator.id]
   const planActionIdsByIndicator = useSelector((state) => {
     return state.planActionIdsByIndicator

--- a/app/javascript/src/config/reducers.js
+++ b/app/javascript/src/config/reducers.js
@@ -19,14 +19,6 @@ export default function initReducers(initialState) {
   const technicalAreas = createReducer(initialState.technicalAreas, {})
 
   const indicators = createReducer(initialState.indicators, {})
-  const indicatorMapInitial = initialState.indicators.reduce(
-    (map, indicator) => {
-      map[indicator.id] = indicator
-      return map
-    },
-    {}
-  )
-  const indicatorMap = createReducer(indicatorMapInitial, {})
 
   const actionMap = initialState.actions.reduce((map, action) => {
     map[action.id] = action
@@ -66,7 +58,6 @@ export default function initReducers(initialState) {
       )
     }
   })
-
   const planActionIdsByIndicator = createReducer(
     initialMapOfPlanActionIdsByIndicator,
     {
@@ -84,7 +75,6 @@ export default function initReducers(initialState) {
       },
     }
   )
-
   const planActionIdsNotInIndicator = createReducer(
     initialMapOfPlanActionIdsNotInIndicator,
     {
@@ -135,11 +125,7 @@ export default function initReducers(initialState) {
     },
   })
 
-  const initialPlanGoalMap = initialState.planGoals.reduce((acc, goal) => {
-    acc[goal.benchmark_indicator_id] = goal
-    return acc
-  }, {})
-  const planGoalMap = createReducer(initialPlanGoalMap, {})
+  const planGoals = createReducer(initialState.planGoals, {})
 
   const nudgesByActionType = createReducer(initialState.nudgesByActionType, {})
 
@@ -152,9 +138,9 @@ export default function initReducers(initialState) {
   return combineReducers({
     technicalAreas,
     indicators,
-    indicatorMap,
     actions,
     planActionIds,
+    planGoals,
     planActionIdsByIndicator,
     planActionIdsNotInIndicator,
     planChartLabels,
@@ -162,7 +148,6 @@ export default function initReducers(initialState) {
     selectedTechnicalAreaId,
     selectedActionTypeOrdinal,
     selectedListMode,
-    planGoalMap,
     nudgesByActionType,
     plan,
   })

--- a/app/javascript/src/config/selectors.js
+++ b/app/javascript/src/config/selectors.js
@@ -1,9 +1,20 @@
 import { createSelector } from "reselect"
 
+const getAllTechnicalAreas = (state) => state.technicalAreas
+const getAllIndicators = (state) => state.indicators
 const getAllActions = (state) => state.allActions
+const getActionTypes = (state) => state.nudgesByActionType
+const getNumOfActionTypes = (state) => getActionTypes(state).length
+
 const getPlanActionIds = (state) => state.planActionIds
-const getNumOfActionTypes = (state) => state.nudgesByActionType.length
-const getTechnicalAreas = (state) => state.technicalAreas
+const getPlanGoals = (state) => state.planGoals
+
+const getPlanGoalMap = createSelector([getPlanGoals], (goals) => {
+  return goals.reduce((acc, goal) => {
+    acc[goal.benchmark_indicator_id] = goal
+    return acc
+  }, {})
+})
 
 const getActionsForIds = createSelector(
   [getPlanActionIds, getAllActions],
@@ -12,8 +23,8 @@ const getActionsForIds = createSelector(
   }
 )
 
-const technicalAreaMap = createSelector(
-  [getTechnicalAreas],
+const getTechnicalAreaMap = createSelector(
+  [getAllTechnicalAreas],
   (technicalAreas) => {
     return technicalAreas.reduce((map, technicalArea) => {
       map[technicalArea.id] = technicalArea
@@ -22,8 +33,15 @@ const technicalAreaMap = createSelector(
   }
 )
 
+const getIndicatorMap = createSelector([getAllIndicators], (indicators) => {
+  return indicators.reduce((map, indicator) => {
+    map[indicator.id] = indicator
+    return map
+  }, {})
+})
+
 const countActionsByTechnicalArea = createSelector(
-  [getActionsForIds, technicalAreaMap],
+  [getActionsForIds, getTechnicalAreaMap],
   (currentActions, technicalAreaMap) => {
     return currentActions.reduce((acc, action) => {
       const technicalArea = technicalAreaMap[action.benchmark_technical_area_id]
@@ -67,10 +85,16 @@ const getFormAuthenticityToken = () =>
 const getFormActionUrl = () => window.STATE_FROM_SERVER.formActionUrl
 
 export {
+  getAllTechnicalAreas,
+  getAllIndicators,
   getAllActions,
-  getPlanActionIds,
+  getActionTypes,
   getNumOfActionTypes,
+  getPlanActionIds,
+  getPlanGoalMap,
   getActionsForIds,
+  getTechnicalAreaMap,
+  getIndicatorMap,
   countActionsByTechnicalArea,
   countActionsByActionType,
   getFormAuthenticityToken,

--- a/test/javascript/src/components/list/Action.test.js
+++ b/test/javascript/src/components/list/Action.test.js
@@ -39,11 +39,7 @@ beforeEach(() => {
       "Domestic legislation, laws, regulations, policy an…rs and effectively enable compliance with the IHR",
   }
   useSelector
-    .mockImplementationOnce((callback) =>
-      callback({
-        indicatorMap: { 13: indicator },
-      })
-    )
+    .mockReturnValueOnce({ 13: indicator })
     .mockImplementationOnce((callback) =>
       callback({
         actions: { 17: action },

--- a/test/javascript/src/components/list/IndicatorActionList.test.js
+++ b/test/javascript/src/components/list/IndicatorActionList.test.js
@@ -29,11 +29,7 @@ describe("when a goal is present", () => {
   describe("and there are actions present", () => {
     beforeEach(() => {
       useSelector
-        .mockImplementationOnce((callback) =>
-          callback({
-            planGoalMap: { 17: { id: 17 } },
-          })
-        )
+        .mockReturnValueOnce({ 17: { id: 17 } })
         .mockImplementationOnce((callback) =>
           callback({
             planActionIdsByIndicator: { 17: [2, 5, 7, 11, 13] },
@@ -61,11 +57,7 @@ describe("when a goal is present", () => {
   describe("and there are zero actions", () => {
     beforeEach(() => {
       useSelector
-        .mockImplementationOnce((callback) =>
-          callback({
-            planGoalMap: { 17: { id: 17 } },
-          })
-        )
+        .mockReturnValueOnce({ 17: { id: 17 } })
         .mockImplementationOnce((callback) =>
           callback({
             planActionIdsByIndicator: { 17: [] },
@@ -93,17 +85,11 @@ describe("when a goal is present", () => {
 
 describe("when there is no goal", () => {
   beforeEach(() => {
-    useSelector
-      .mockImplementationOnce((callback) =>
-        callback({
-          planGoalMap: {},
-        })
-      )
-      .mockImplementation((callback) =>
-        callback({
-          planActionIdsByIndicator: {},
-        })
-      )
+    useSelector.mockReturnValueOnce({}).mockImplementation((callback) =>
+      callback({
+        planActionIdsByIndicator: {},
+      })
+    )
   })
 
   it("does not render any child AddAction components and instead renders a NoGoalForThisIndicator", () => {

--- a/test/javascript/src/config/selectors.test.js
+++ b/test/javascript/src/config/selectors.test.js
@@ -6,6 +6,9 @@ import {
   getPlanActionIds,
   getNumOfActionTypes,
   getActionsForIds,
+  getTechnicalAreaMap,
+  getIndicatorMap,
+  getPlanGoalMap,
   countActionsByTechnicalArea,
   countActionsByActionType,
 } from "config/selectors"
@@ -23,6 +26,8 @@ beforeAll(() => {
     planActionIds: stateFromServer.planActionIds,
     nudgesByActionType: stateFromServer.nudgesByActionType,
     technicalAreas: stateFromServer.technicalAreas,
+    indicators: stateFromServer.indicators,
+    planGoals: stateFromServer.planGoals,
   }
   store = mockStore(initialState)
 })
@@ -35,6 +40,52 @@ describe("getAllActions", () => {
 
     expect(result).toBeInstanceOf(Array)
     expect(result.length).toEqual(876)
+  })
+})
+
+describe("getTechnicalAreaMap", () => {
+  it("returns a hash map of technicalArea.id => technicalArea", () => {
+    const state = store.getState()
+
+    const result = getTechnicalAreaMap(state)
+
+    expect(result).toBeInstanceOf(Object)
+    expect(result[3].id).toEqual(3)
+    expect(result[3].sequence).toEqual(3)
+    expect(result[3].text).toEqual("Antimicrobial Resistance")
+  })
+})
+
+describe("getIndicatorMap", () => {
+  it("returns a hash map of indicator.id => indicator", () => {
+    const state = store.getState()
+
+    const result = getIndicatorMap(state)
+
+    expect(result).toBeInstanceOf(Object)
+    expect(result[2].id).toEqual(2)
+    expect(result[2].sequence).toEqual(2)
+    expect(result[2].text).toEqual(
+      "Financing is available for the implementation of IHR capacities"
+    )
+    expect(result[2].objective).toEqual(
+      "To ensure financing is available for the implementation of IHR capacities"
+    )
+  })
+})
+
+describe("getPlanGoalMap", () => {
+  it("returns a hash map of goal.id => goal", () => {
+    const state = store.getState()
+
+    const result = getPlanGoalMap(state)
+
+    expect(result).toBeInstanceOf(Object)
+    expect(result[1]).toBeInstanceOf(Object)
+    expect(result[1].id).not.toBeNull()
+    expect(result[1].plan_id).not.toBeNull()
+    expect(result[1].value).not.toBeNull()
+    expect(result[1].benchmark_indicator_id).not.toBeNull()
   })
 })
 


### PR DESCRIPTION
Factor out indicatorMap and planGoalMap code from reducers to selectors, update components that use them and tests. Add tests for selectors getTechnicalAreaMap and getIndicatorMap. All tests green.