### PR TITLE
Add disease table and PlanDisease table

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -28,6 +28,7 @@ class PlansController < ApplicationController
     @countries = Country.all_assessed
     @technical_areas_jee1 = AssessmentTechnicalArea.jee1
     @technical_areas_spar_2018 = AssessmentTechnicalArea.spar_2018
+    @influenza = Disease.influenza
     @get_started_form = GetStartedForm.new get_started_params.to_h
     @redirect_key = GET_STARTED_REDIRECT_KEY
     if request.post? && request.xhr?

--- a/app/lib/get_started_form.rb
+++ b/app/lib/get_started_form.rb
@@ -78,6 +78,6 @@ class GetStartedForm
   end
 
   def valid_diseases?
-    errors.add(:diseases, "Invalid disease id") unless diseases.empty? || diseases.all? { |disease| Plan::DISEASE_TYPES.include?(disease) }
+    errors.add(:diseases, "Invalid disease id") if Disease.where(id: diseases).count != diseases.length
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -18,5 +18,6 @@ class ApplicationRecord < ActiveRecord::Base
     BenchmarkTechnicalArea
     BenchmarkIndicator
     BenchmarkIndicatorAction
+    Disease
   ]
 end

--- a/app/models/concerns/disease_seed.rb
+++ b/app/models/concerns/disease_seed.rb
@@ -1,0 +1,16 @@
+module DiseaseSeed
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def seed!
+      return unless Disease.count.zero?
+
+      warn "Seeding data for Diseases..."
+      Disease.create!(display: 'Influenza', name: 'influenza')
+    end
+
+    def unseed!
+      ActiveRecord::Base.connection.exec_query("DELETE FROM #{table_name}")
+    end
+  end
+end

--- a/app/models/disease.rb
+++ b/app/models/disease.rb
@@ -1,0 +1,4 @@
+class Disease < ApplicationRecord
+  include DiseaseSeed
+  scope :influenza, -> { find_by_name("influenza") }
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -10,9 +10,6 @@ class Plan < ApplicationRecord
   # TODO: update this implementation once the assessments page is modernized
   ASSESSMENT_TYPE_NAMED_IDS = %w[jee1 spar_2018 from-technical-areas].freeze
   TERM_TYPES = [100, 500] # 100 is 1-year, 500 is 5-year
-  DISEASE_TYPES = [
-      10, # influenza
-  ].freeze
   include PlanBuilder
 
   belongs_to :assessment
@@ -20,6 +17,8 @@ class Plan < ApplicationRecord
   has_many :goals, class_name: "PlanGoal", dependent: :destroy
   has_many :plan_actions, dependent: :destroy
   has_many :benchmark_indicator_actions, through: :plan_actions
+  has_many :plan_diseases
+  has_many :diseases, through: :plan_diseases
 
   delegate :alpha3, to: :country
   delegate :jee1?, :spar_2018?, :type_description, to: :assessment

--- a/app/models/plan_disease.rb
+++ b/app/models/plan_disease.rb
@@ -1,0 +1,4 @@
+class PlanDisease < ApplicationRecord
+  belongs_to :plan
+  belongs_to :disease
+end

--- a/app/views/plans/get_started.html.haml
+++ b/app/views/plans/get_started.html.haml
@@ -106,11 +106,11 @@
           %h4{class: heading_disabled_class} 4. Do you want to add disease specific planning?
           - if @get_started_form.country.present?
             .form-check
-              = check_box_tag "get_started_form[diseases][]", Plan::DISEASE_TYPES.first, false,
+              = check_box_tag "get_started_form[diseases][]", @influenza.id, false,
                 {class: "form-check-inline",
                   id: "diseases_influenza"}
               %label{for: "diseases_influenza"}
-                Optional: Influenza planning
+                = "Optional: #{@influenza.display} planning"
           - else
             %div{style: "height: 75px"}
 

--- a/db/migrate/20200702214913_create_disease.rb
+++ b/db/migrate/20200702214913_create_disease.rb
@@ -1,0 +1,9 @@
+class CreateDisease < ActiveRecord::Migration[5.2]
+  def change
+    create_table :diseases do |t|
+      t.string :display
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200703001806_create_join_table_plans_diseases.rb
+++ b/db/migrate/20200703001806_create_join_table_plans_diseases.rb
@@ -1,0 +1,9 @@
+class CreateJoinTablePlansDiseases < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :plans, :diseases, table_name: :plan_diseases do |t|
+      t.index [:plan_id, :disease_id], unique:true
+    end
+    add_foreign_key :plan_diseases, :plans
+    add_foreign_key :plan_diseases, :diseases
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_22_165716) do
+ActiveRecord::Schema.define(version: 2020_07_03_001806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,13 @@ ActiveRecord::Schema.define(version: 2020_05_22_165716) do
     t.index ["name"], name: "index_countries_on_name", unique: true
   end
 
+  create_table "diseases", force: :cascade do |t|
+    t.string "display"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "plan_actions", force: :cascade do |t|
     t.integer "plan_id"
     t.integer "benchmark_indicator_action_id"
@@ -119,6 +126,12 @@ ActiveRecord::Schema.define(version: 2020_05_22_165716) do
     t.integer "benchmark_indicator_id"
     t.integer "benchmark_technical_area_id"
     t.index ["plan_id"], name: "index_plan_actions_on_plan_id"
+  end
+
+  create_table "plan_diseases", id: false, force: :cascade do |t|
+    t.bigint "plan_id", null: false
+    t.bigint "disease_id", null: false
+    t.index ["plan_id", "disease_id"], name: "index_plan_diseases_on_plan_id_and_disease_id", unique: true
   end
 
   create_table "plan_goals", force: :cascade do |t|

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -65,7 +65,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
              xhr: true,
              params: {
                  get_started_form: {
-                     country_id: "162", assessment_type: "jee1", plan_term: "1", diseases: [10]
+                     country_id: "162", assessment_type: "jee1", plan_term: "1", diseases: [Disease.influenza.id]
                  },
              }
         assert_response :success
@@ -80,7 +80,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
                     country_name: "Nigeria",
                     assessment_type: "jee1",
                     plan_term: "1-year",
-                    diseases: "10",
+                    diseases: Disease.influenza.id.to_s,
                 },
             )
         response_body.end_with?(redirect_url).must_equal true

--- a/test/lib/get_started_form_test.rb
+++ b/test/lib/get_started_form_test.rb
@@ -31,7 +31,7 @@ describe GetStartedForm do
       # 162 is Nigeria
       assessment_type: "jee1",
       plan_term: "5",
-      diseases: [Plan::DISEASE_TYPES.first]
+      diseases: [Disease.influenza.id]
     }
   end
 
@@ -154,7 +154,7 @@ describe GetStartedForm do
     end
 
     it "returns an expected value for diseases" do
-      subject.diseases.must_equal [Plan::DISEASE_TYPES.first]
+      subject.diseases.must_equal [Disease.influenza.id]
     end
   end
 


### PR DESCRIPTION
These tables are needed for both stories that are in flight: 

#172949058 Add to Get Started page a section for disease-specific planning for influenza, and pass the param through
#172948970 Process the spreadsheet into a JSON data file, and insert into the DB in a migration

Changes include adding two new tables, Disease and PlanDiseases join table, a DiseaseSeed to seed the data with Influenza, and associated code and test cleanup 