### PR TITLE
When I create a plan from the Goal-setting page any disease-specific selection to persist as part of the saved plan

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,0 +1,11 @@
+module Exceptions
+  class InvalidDiseasesError < StandardError
+    attr_reader :status, :error, :message
+
+    def initialize(_error = nil, _status = nil, _message = nil)
+      @error = _error || 422
+      @status = _status || :unprocessable_entity
+      @message = _message || "One or more of the diseases selected is invalid. Please go back to the Get Started page to start over."
+    end
+  end
+end

--- a/app/models/concerns/plan_builder.rb
+++ b/app/models/concerns/plan_builder.rb
@@ -76,6 +76,7 @@ module PlanBuilder
       assessment:,
       plan_name:,
       is_5_year_plan: false,
+      disease_ids: [],
       user: nil
     )
       num_of_underscores = assessment.spar_2018? ? 3 : 2
@@ -146,6 +147,13 @@ module PlanBuilder
           end
         end
       end
+
+      begin
+        plan.disease_ids = disease_ids
+      rescue ActiveRecord::RecordNotFound =>  e
+        raise Exceptions::InvalidDiseasesError
+      end
+
       Plan.transaction do
         plan.goals = plan_goals
         plan.plan_actions = plan_actions

--- a/app/views/plans/goals.html.erb
+++ b/app/views/plans/goals.html.erb
@@ -24,6 +24,7 @@
                } do |form| %>
     <%= form.hidden_field :assessment_id %>
     <%= form.hidden_field :term %>
+    <%= form.hidden_field :disease_ids, value: @disease_ids %>
 
     <% counter = 0 %>
     <div class="row py-4">

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -157,7 +157,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
           post plans_url,
                params: {
                  plan: {
-                   assessment_id: "123", term: "100", indicators: { abc: "123" }
+                   assessment_id: "123", term: "100", indicators: { abc: "123" }, disease_ids: ""
                  },
                }
           assert_response :redirect
@@ -175,6 +175,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
                      assessment_id: "123",
                      term: "500",
                      indicators: { abc: "123" },
+                     disease_ids: "10",
                    },
                  }
             assert_response :redirect
@@ -189,15 +190,33 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
           Plan.stub(:create_from_goal_form, plan) do
             post plans_url,
                  params: {
-                   plan: {
-                     assessment_id: "123",
-                     term: "100",
-                     indicators: { abc: "123" },
-                   },
+                     plan: {
+                         assessment_id: "123",
+                         term: "100",
+                         indicators: {abc: "123"},
+                         disease_ids: ""
+                     },
                  }
             assert_response :redirect
             assert_redirected_to root_path
           end
+        end
+      end
+
+      describe "when the disease_ids have been tampered with" do
+        it "responds with a flash message and redirect" do
+          post plans_url,
+               params: {
+                   plan: {
+                       assessment_id: "123",
+                       term: "100",
+                       indicators: {abc: "123"},
+                       disease_ids: "0", # 0 does not exist as a disease id
+                   },
+               }
+          assert_response :redirect
+          assert_equal Exceptions::InvalidDiseasesError.new.message, flash[:notice]
+          assert_redirected_to root_path
         end
       end
     end

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -324,6 +324,66 @@ describe Plan do
         assert_equal 33, plan.plan_actions.size
       end
     end
+    describe "for Nigeria JEE1 with influenza" do
+      let(:indicator_attrs) do
+        {
+            jee1_ind_p11: "1",
+            jee1_ind_p11_goal: "2",
+        }.with_indifferent_access
+      end
+      let(:plan) do
+        Plan.create_from_goal_form(
+            indicator_attrs: indicator_attrs,
+            assessment: assessment_for_nigeria_jee1,
+            plan_name: "test plan 3854",
+            disease_ids: [Disease.influenza.id]
+            )
+      end
+
+      it "returns a saved plan instance" do
+        assert plan.persisted?, "Plan was not saved"
+      end
+
+      it "has the expected term" do
+        plan.term.must_equal Plan::TERM_TYPES.first
+      end
+
+      it "has the expected name" do
+        assert_equal "test plan 3854", plan.name
+      end
+
+      it "has the expected number of indicators" do
+        assert_equal 1, plan.goals.size
+      end
+
+      it "has the expected number of actions" do
+        assert_equal 6, plan.plan_actions.size
+      end
+
+      it "has associated diseases influenza" do
+        assert_equal plan.diseases, [Disease.influenza]
+      end
+    end
+
+    describe "for Nigeria JEE1 with an invalid disease" do
+      let(:indicator_attrs) do
+        {
+            jee1_ind_p11: "1",
+            jee1_ind_p11_goal: "2",
+        }.with_indifferent_access
+      end
+
+      it "raises an exception" do
+        assert_raise Exceptions::InvalidDiseasesError do
+          Plan.create_from_goal_form(
+              indicator_attrs: indicator_attrs,
+              assessment: assessment_for_nigeria_jee1,
+              plan_name: "test plan 3854",
+              disease_ids: [0] # disease id 0 does not exist
+          )
+        end
+      end
+    end
   end
 
   describe "#count_actions_by_type" do


### PR DESCRIPTION
[#172951094] When I create a plan from the Goal-setting page any disease-specific selection to persist as part of the saved plan

Code changes include:
- forwarding the diseases query param on the previous page to goals.html.erb as a hidden field 
- showing a flash message and redirect if the user tampered with the disease ids
- raising an exception in PlanBuilder to handle the tamper detection