### PR TITLE
When filtering activities by Activity Type the list rendered should display Influenza-specific activities in the expected order and format

### DIFF
--- a/app/javascript/src/components/List/Action.js
+++ b/app/javascript/src/components/List/Action.js
@@ -8,11 +8,9 @@ import ActionBadgeDisease from "./ActionBadgeDisease"
 import ActionBadgePill from "./ActionBadgePill"
 
 const Action = (props) => {
-  const id = props.id
+  const action = props.action
   const dispatch = useDispatch()
   const indicatorMap = useSelector((state) => getIndicatorMap(state))
-  const actionMap = useSelector((state) => state.actions)
-  const action = actionMap[id]
   const indicator = indicatorMap[action.benchmark_indicator_id]
 
   return (
@@ -46,7 +44,7 @@ const Action = (props) => {
 }
 
 Action.propTypes = {
-  id: PropTypes.number.isRequired,
+  action: PropTypes.object.isRequired,
 }
 
 export default Action

--- a/app/javascript/src/components/List/ActionListByActionType.js
+++ b/app/javascript/src/components/List/ActionListByActionType.js
@@ -1,8 +1,13 @@
 import React from "react"
 import { useSelector } from "react-redux"
 import {
+  getActionsForIds,
+  getAllActions,
+  getIndicatorMap,
   getPlanActionIds,
   getSelectedActionTypeOrdinal,
+  getSortedActions,
+  getTechnicalAreaMap,
 } from "../../config/selectors"
 import Action from "./Action"
 
@@ -17,13 +22,25 @@ const ActionListByActionType = () => {
     const action_types = currentAction.action_types || []
     return action_types.indexOf(selectedActionTypeOrdinal) >= 0
   })
-  const actionComponents = actionIdsToDisplay.map((actionId) => {
-    return <Action id={actionId} key={actionId} />
+  const actions = useSelector((state) => getAllActions(state))
+  const actionsToDisplay = getActionsForIds(actionIdsToDisplay, actions)
+  const technicalAreaMap = useSelector((state) => getTechnicalAreaMap(state))
+  const indicatorMap = useSelector((state) => getIndicatorMap(state))
+  const sortedActions = getSortedActions(
+    actionsToDisplay,
+    technicalAreaMap,
+    indicatorMap
+  )
+
+  const actionComponents = sortedActions.map((action) => {
+    return <Action action={action} key={`action-${action.id}`} />
   })
+
   const chartLabels = useSelector((state) => state.planChartLabels)
   const chartLabelsByActionType = chartLabels[1]
   const nameOfSelectedActionType =
     chartLabelsByActionType[selectedActionTypeOrdinal - 1]
+
   return (
     <div id="action-list-by-type-container" className="col-auto w-100">
       <h2>{nameOfSelectedActionType} Actions</h2>

--- a/app/javascript/src/components/List/IndicatorActionList.js
+++ b/app/javascript/src/components/List/IndicatorActionList.js
@@ -2,11 +2,13 @@ import React from "react"
 import PropTypes from "prop-types"
 import { useSelector } from "react-redux"
 import {
-  getPlanGoalMap,
-  getPlanActionIdsByIndicator,
+  getActionsForIds,
   getAllActions,
-  getActionsForIndicator,
-  getSortedActionsForIndicator,
+  getIndicatorMap,
+  getPlanActionIdsByIndicator,
+  getPlanGoalMap,
+  getSortedActions,
+  getTechnicalAreaMap,
 } from "../../config/selectors"
 import Action from "./Action"
 import NoGoalForThisIndicator from "./NoGoalForThisIndicator"
@@ -21,12 +23,13 @@ const IndicatorActionList = (props) => {
   )
   const actionIdsByIndicator = planActionIdsByIndicator[indicator.id]
   const actions = useSelector((state) => getAllActions(state))
-  const actionsForIndicator = getActionsForIndicator(
-    actionIdsByIndicator,
-    actions
-  )
-  const sortedActionsByIndicator = getSortedActionsForIndicator(
-    actionsForIndicator
+  const technicalAreaMap = useSelector((state) => getTechnicalAreaMap(state))
+  const indicatorMap = useSelector((state) => getIndicatorMap(state))
+  const actionsForIndicator = getActionsForIds(actionIdsByIndicator, actions)
+  const sortedActionsByIndicator = getSortedActions(
+    actionsForIndicator,
+    technicalAreaMap,
+    indicatorMap
   )
 
   if (!goalForThisIndicator) {
@@ -34,7 +37,7 @@ const IndicatorActionList = (props) => {
   }
 
   const actionComponents = sortedActionsByIndicator.map((action) => (
-    <Action id={action.id} key={`action-${action.id}`} />
+    <Action action={action} key={`action-${action.id}`} />
   ))
   return (
     <>

--- a/test/javascript/src/components/List/Action.test.js
+++ b/test/javascript/src/components/List/Action.test.js
@@ -36,13 +36,8 @@ beforeEach(() => {
     text:
       "Domestic legislation, laws, regulations, policy an…rs and effectively enable compliance with the IHR",
   }
-  useSelector
-    .mockReturnValueOnce({ 13: indicator })
-    .mockImplementationOnce((callback) =>
-      callback({
-        actions: { 17: action },
-      })
-    )
+  const mockIndicatorMap = { 13: indicator }
+  useSelector.mockReturnValueOnce(mockIndicatorMap)
 })
 
 afterEach(() => {
@@ -66,7 +61,10 @@ describe("when the action is not disease specific", () => {
 
   it("Action has the expected badge, level, ordinal, title, and pill", () => {
     act(() => {
-      ReactDOM.render(<Action id={action.id} key={action.id} />, container)
+      ReactDOM.render(
+        <Action action={action} key={`action-${action.id}`} />,
+        container
+      )
     })
 
     expect(container.innerHTML).toMatch(action.text)
@@ -82,7 +80,10 @@ describe("when the action is not disease specific", () => {
     useDispatch.mockReturnValueOnce(mockUseDispatch)
 
     act(() => {
-      ReactDOM.render(<Action id={action.id} key={action.id} />, container)
+      ReactDOM.render(
+        <Action action={action} key={`action-${action.id}`} />,
+        container
+      )
     })
     $(".delete.close", container).trigger("click")
 
@@ -107,7 +108,10 @@ describe("when the Action is disease specific", () => {
 
   it("Action has the expected disease badge, ordinal, title and pill", () => {
     act(() => {
-      ReactDOM.render(<Action id={action.id} key={action.id} />, container)
+      ReactDOM.render(
+        <Action action={action} key={`action-${action.id}`} />,
+        container
+      )
     })
 
     expect(container.innerHTML).toMatch(action.text)

--- a/test/javascript/src/components/List/ActionListByActionType.test.js
+++ b/test/javascript/src/components/List/ActionListByActionType.test.js
@@ -3,23 +3,55 @@ import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 import { useSelector } from "react-redux"
 import ActionListByActionType from "components/List/ActionListByActionType"
+import * as selectors from "config/selectors"
 
 jest.mock("components/List/Action", () => () => <mock-action />)
 jest.mock("react-redux", () => ({
   useSelector: jest.fn(),
 }))
 
-let container
+let container, spyGetSortedActions
+
 beforeEach(() => {
   container = document.createElement("div")
   document.body.appendChild(container)
   const selectedActionTypeOrdinal = 3
-  const action1 = { id: 17, action_types: null }
-  const action2 = { id: 19, action_types: [selectedActionTypeOrdinal] }
-  const action3 = { id: 37, action_types: [3, selectedActionTypeOrdinal] }
-  const action4 = { id: 41, action_types: [3, 17, selectedActionTypeOrdinal] }
-  const action5 = { id: 47, action_types: [] }
-  const action6 = { id: 53, action_types: [selectedActionTypeOrdinal] }
+  const action1 = {
+    id: 17,
+    action_types: null,
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
+  const action2 = {
+    id: 19,
+    action_types: [selectedActionTypeOrdinal],
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
+  const action3 = {
+    id: 37,
+    action_types: [3, selectedActionTypeOrdinal],
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
+  const action4 = {
+    id: 41,
+    action_types: [3, 17, selectedActionTypeOrdinal],
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
+  const action5 = {
+    id: 47,
+    action_types: [],
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
+  const action6 = {
+    id: 53,
+    action_types: [selectedActionTypeOrdinal],
+    benchmark_technical_area_id: 1,
+    benchmark_indicator_id: 1,
+  }
   // TODO: factor out this planChartLabels data to DRY up this and other uses prob into a file instead.
   const planChartLabels = [
     [
@@ -60,29 +92,36 @@ beforeEach(() => {
       "Training",
     ],
   ]
+  let mockPlanActionIds = [
+    action1.id,
+    action2.id,
+    action3.id,
+    action4.id,
+    action5.id,
+    // action6 intentionally because in this example it does not belong to the plan
+  ]
+  const mockActionMap = {
+    [action1.id]: action1,
+    [action2.id]: action2,
+    [action3.id]: action3,
+    [action4.id]: action4,
+    [action5.id]: action5,
+    [action6.id]: action6,
+  }
+  const mockActions = [action1, action2, action3, action4, action5, action6]
+  const mockTechnicalAreaMap = { 1: {} }
+  const indicatorMap = { 1: {} }
+
   useSelector
-    .mockReturnValueOnce([
-      // action6 intentionally omitted from next line because in this example it does not belong to the plan
-      action1.id,
-      action2.id,
-      action3.id,
-      action4.id,
-      action5.id,
-    ])
-    .mockImplementationOnce((callback) => {
-      const actions = {}
-      actions[action1.id] = action1
-      actions[action2.id] = action2
-      actions[action3.id] = action3
-      actions[action4.id] = action4
-      actions[action5.id] = action5
-      actions[action6.id] = action6
-      return callback({
-        actions: actions,
-      })
-    })
+    .mockReturnValueOnce(mockPlanActionIds)
+    .mockReturnValueOnce(mockActionMap)
     .mockReturnValueOnce(selectedActionTypeOrdinal)
-    .mockImplementationOnce((cb) => cb({ planChartLabels: planChartLabels }))
+    .mockReturnValueOnce(mockActions)
+    .mockReturnValueOnce(mockTechnicalAreaMap)
+    .mockReturnValueOnce(indicatorMap)
+    .mockReturnValueOnce(planChartLabels)
+
+  spyGetSortedActions = jest.spyOn(selectors, "getSortedActions")
 })
 
 afterEach(() => {
@@ -90,13 +129,13 @@ afterEach(() => {
   container = null
 })
 
-it("when passed 3 Action Ids it renders 3 Action component children", () => {
+it("it renders 3 sorted Action component children", () => {
   act(() => {
     ReactDOM.render(<ActionListByActionType />, container)
   })
   const foundActionListByActionTypeComponents = container.querySelectorAll(
     "mock-action"
   )
-
   expect(foundActionListByActionTypeComponents.length).toEqual(3)
+  expect(spyGetSortedActions).toHaveBeenCalled()
 })

--- a/test/javascript/src/components/List/IndicatorActionList.test.js
+++ b/test/javascript/src/components/List/IndicatorActionList.test.js
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 import { useSelector } from "react-redux"
 import IndicatorActionList from "components/List/IndicatorActionList"
+import * as selectors from "config/selectors"
 
 jest.mock("react-redux", () => ({
   useSelector: jest.fn(),
@@ -14,10 +15,12 @@ jest.mock("components/List/NoGoalForThisIndicator", () => () => (
   <mock-NoGoalForThisIndicator />
 ))
 
-let container
+let container, spyGetSortedActions
+
 beforeEach(() => {
   container = document.createElement("div")
   document.body.appendChild(container)
+  spyGetSortedActions = jest.spyOn(selectors, "getSortedActions")
 }),
   afterEach(() => {
     document.body.removeChild(container)
@@ -27,22 +30,26 @@ beforeEach(() => {
 describe("when a goal is present", () => {
   describe("and there are actions present", () => {
     beforeEach(() => {
-      let mockPlanGoalMap = { 17: { id: 1 } }
-      let mockPlanActionIdsByIndicator = { 17: [2, 11, 5] }
-      let mockAllActions = [
-        { id: 2 },
-        { id: 5 },
-        { id: 13 },
-        { id: 11 },
-        { i2: 6 },
+      const mockPlanGoalMap = { 17: { id: 1 } }
+      const mockPlanActionIdsByIndicator = { 17: [2, 11, 5] }
+      const mockAllActions = [
+        { id: 2, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
+        { id: 5, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
+        { id: 13, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
+        { id: 11, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
+        { i2: 6, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
       ]
+      const mockTechnicalAreaMap = { 1: {} }
+      const indicatorMap = { 1: {} }
       useSelector
         .mockReturnValueOnce(mockPlanGoalMap)
         .mockReturnValueOnce(mockPlanActionIdsByIndicator)
         .mockReturnValueOnce(mockAllActions)
+        .mockReturnValueOnce(mockTechnicalAreaMap)
+        .mockReturnValueOnce(indicatorMap)
     })
 
-    it("renders 5 child Action components and 1 child AddAction component", () => {
+    it("renders 3 sorted child Action components and 1 child AddAction component", () => {
       act(() => {
         ReactDOM.render(
           <IndicatorActionList indicator={{ id: 17 }} />,
@@ -56,6 +63,7 @@ describe("when a goal is present", () => {
 
       expect(foundActionComponents.length).toEqual(3)
       expect(foundAddActionComponents.length).toEqual(1)
+      expect(spyGetSortedActions).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
When filtering activities by Activity Type the list rendered should display Influenza-specific activities in the expected order and format

[#172948930]

Code changes include:
* sort the actions in `ActionListByActionType`
* Change `<Action />` component to receive props.action instead of props.id
* rename `selectors#getSortedActionsByIndicator` to `getSortedActions` so that can use in two components
* rename `selectors#getActionsForIds` to `getActionsForPlan` and created a new method `getActionsForIds`
* modified `getSortedActions` to sort by `disease_id ASC, technical_area.sequence, indicator.sequence ASC, action.level ASC, action.sequence ASC`, and tested
