### PR TITLE
Influenza plans fail to be deleted due to an error

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -18,7 +18,7 @@ class Plan < ApplicationRecord
   has_many :plan_actions, dependent: :destroy
   has_many :benchmark_indicator_actions, through: :plan_actions
   has_many :plan_diseases
-  has_many :diseases, through: :plan_diseases
+  has_many :diseases, through: :plan_diseases, dependent: :destroy
 
   delegate :alpha3, to: :country
   delegate :jee1?, :spar_2018?, :type_description, to: :assessment

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -200,6 +200,11 @@ class AppsTest < ApplicationSystemTestCase
     assert_current_path("/plans")
     assert page.has_content?("Welcome! You have signed up successfully.")
     assert page.has_content?("Saved Nigeria Plan 789") # ugh without this form field(s) dont get filled
+
+    ##
+    # delete the plan
+    click_link("Delete")
+    assert page.has_content?("You haven't started any plans yet")
   end
 
   test "happy path for Armenia SPAR 2018 5-year plan" do


### PR DESCRIPTION
Influenza plans fail to be deleted due to an error

[#173931450]

Code changes include:
* adding dependent: :destroy to the has_many :diseases
* system test to make sure can delete a plan with influenza


