### PR TITLE
Click bar segment make inactive bars pale for both Technical Area and Action Type tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ and triggers re-compile upon save.
 
 The application should now be available [on localhost](https://localhost:3000/)
 
+## A Note on 3rd party libraries used
+
+Tooltips: We are using bootstrap .tooltip() and not jQuery .tooltip(). It is used the same way `$('.selector').tooltip()`, and has different options.
+
 ## Fixtures
 
 TODO: This needs updated, much of it no longer applies.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,8 +31,10 @@ $colors: (
   "text-disabled": #ababab,
   "health-system": #0d4a59,
   "health-system-hover": #073642,
+  "health-system-deselected": #86a4ac,
   "disease-influenza": #4e838f,
   "disease-influenza-hover": #3f6d78,
+  "disease-influenza-deselected": #a6c1c7,
   "disease-pill": #57575d,
 ) !default;
 

--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -251,12 +251,20 @@
   .ct-series-a .ct-bar {
     stroke: color("health-system");
 
+    &.ct-deselected {
+      stroke: color("health-system-deselected");
+    }
+
     &:hover {
       stroke: color("health-system-hover");
     }
   }
   .ct-series-b .ct-bar {
     stroke: color("disease-influenza");
+
+    &.ct-deselected {
+      stroke: color("disease-influenza-deselected");
+    }
 
     &:hover {
       stroke: color("disease-influenza-hover");

--- a/app/javascript/src/config/selectors.js
+++ b/app/javascript/src/config/selectors.js
@@ -15,6 +15,7 @@ const getSelectedActionTypeOrdinal = (state) =>
 const getPlan = (state) => state.plan
 const getPlanActionIds = (state) => state.planActionIds
 const getPlanGoals = (state) => state.planGoals
+const getPlanChartLabels = (state) => state.planChartLabels
 
 const getPlanGoalMap = createSelector([getPlanGoals], (goals) => {
   return goals.reduce((acc, goal) => {
@@ -223,6 +224,7 @@ export {
   getPlan,
   getPlanActionIds,
   getPlanGoals,
+  getPlanChartLabels,
   getActionMap,
   getPlanGoalMap,
   getActionsForPlan,

--- a/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
@@ -1,26 +1,41 @@
-import fs from "fs"
 import React from "react"
 import { render as renderForConnect } from "../../../test-utils-for-react"
 import BarChartByActionType from "components/ChartCard/BarChartByActionType"
+import {
+  countActionsByActionType,
+  getAllActions,
+  getMatrixOfActionCountsByActionTypeAndDisease,
+  getPlanActionIds,
+  getPlanChartLabels,
+  getSelectedActionTypeOrdinal,
+} from "config/selectors"
 
 jest.mock("components/ChartCard/BarChartLegend", () => () => (
   <mock-BarChartLegend />
 ))
 
-// this taken from Nigeria JEE 1.0 1-yr + Influenza
-const stateFromServerForInfluenza = fs.readFileSync(
-  `${__dirname}/../../../../fixtures/files/state_from_server_with_influenza.json`,
-  "utf-8"
-)
+jest.mock("config/selectors", () => ({
+  countActionsByActionType: jest.fn(),
+  getAllActions: jest.fn(),
+  getMatrixOfActionCountsByActionTypeAndDisease: jest.fn(),
+  getPlanActionIds: jest.fn(),
+  getPlanChartLabels: jest.fn(),
+  getSelectedActionTypeOrdinal: jest.fn(),
+}))
 
 it("BarChartByActionType has the expected 2 divs", () => {
-  const initialState = JSON.parse(stateFromServerForInfluenza)
-  initialState.dispatch = () => {}
+  countActionsByActionType.mockReturnValueOnce([2, 3, 5])
+  getAllActions.mockReturnValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }])
+  getPlanActionIds.mockReturnValueOnce([1, 2])
+  getMatrixOfActionCountsByActionTypeAndDisease.mockReturnValueOnce([
+    [2, 3, 5],
+    [0, 0, 0],
+  ])
+  getPlanChartLabels.mockReturnValueOnce([["label1", "label2", "label3"], []])
+  getSelectedActionTypeOrdinal.mockReturnValueOnce(null)
+
   const renderedComponent = renderForConnect(
-    <BarChartByActionType width="100%" height="240" />,
-    {
-      initialState: initialState,
-    }
+    <BarChartByActionType width="100%" height="240" />
   )
   const container = renderedComponent.container
   const elComponentContainer = container.querySelectorAll(

--- a/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
@@ -1,26 +1,40 @@
-import fs from "fs"
 import React from "react"
 import { render as renderForConnect } from "../../../test-utils-for-react"
 import BarChartByTechnicalArea from "components/ChartCard/BarChartByTechnicalArea"
+import {
+  countActionsByTechnicalArea,
+  getAllActions,
+  getAllTechnicalAreas,
+  getMatrixOfActionCountsByTechnicalAreaAndDisease,
+  getPlanChartLabels,
+  getSelectedTechnicalAreaId,
+} from "config/selectors"
 
 jest.mock("components/ChartCard/BarChartLegend", () => () => (
   <mock-BarChartLegend />
 ))
 
-// this taken from Nigeria JEE 1.0 1-yr + Influenza
-const stateFromServerForInfluenza = fs.readFileSync(
-  `${__dirname}/../../../../fixtures/files/state_from_server_with_influenza.json`,
-  "utf-8"
-)
+jest.mock("config/selectors", () => ({
+  countActionsByTechnicalArea: jest.fn(),
+  getAllActions: jest.fn(),
+  getAllTechnicalAreas: jest.fn(),
+  getMatrixOfActionCountsByTechnicalAreaAndDisease: jest.fn(),
+  getPlanChartLabels: jest.fn(),
+  getSelectedTechnicalAreaId: jest.fn(),
+}))
 
 it("BarChartByTechnicalArea has the expected 2 divs", () => {
-  const initialState = JSON.parse(stateFromServerForInfluenza)
-  initialState.dispatch = () => {}
+  countActionsByTechnicalArea.mockReturnValueOnce([2, 3, 5])
+  getAllActions.mockReturnValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }])
+  getAllTechnicalAreas.mockReturnValueOnce([{ id: 4 }, { id: 5 }, { id: 6 }])
+  getMatrixOfActionCountsByTechnicalAreaAndDisease.mockReturnValueOnce([
+    [2, 3, 5],
+    [0, 0, 0],
+  ])
+  getPlanChartLabels.mockReturnValueOnce([["label1", "label2", "label3"], []])
+  getSelectedTechnicalAreaId.mockReturnValueOnce(null)
   const renderedComponent = renderForConnect(
-    <BarChartByTechnicalArea width="700" height="240" />,
-    {
-      initialState: initialState,
-    }
+    <BarChartByTechnicalArea width="700" height="240" />
   )
   const container = renderedComponent.container
   const elComponentContainer = container.querySelectorAll(

--- a/test/javascript/src/config/selectors.test.js
+++ b/test/javascript/src/config/selectors.test.js
@@ -24,6 +24,7 @@ import {
   getSortedActions,
   getTechnicalAreaMap,
 } from "config/selectors"
+import { getPlanChartLabels } from "../../../../app/javascript/src/config/selectors"
 
 let store
 beforeAll(() => {
@@ -304,6 +305,21 @@ describe("getPlanGoals", () => {
 
     expect(result).toBeInstanceOf(Array)
     expect(result.length).toEqual(39)
+  })
+})
+
+describe("getPlanChartLabels", () => {
+  it("returns the array of arrays of chart labels", () => {
+    const state = store.getState()
+
+    let result = getPlanChartLabels(state)
+
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toEqual(2)
+    expect(result[0]).toBeInstanceOf(Array)
+    expect(result[1]).toBeInstanceOf(Array)
+    expect(result[0].length).toEqual(18)
+    expect(result[1].length).toEqual(15)
   })
 })
 

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -153,11 +153,43 @@ class AppsTest < ApplicationSystemTestCase
              )
     end
 
+    ##
+    # make sure Technical Area tab has a legend
     find("#tabContentForTechnicalArea .ct-legend").has_content?("Influenza specific")
 
+    ##
+    # click on one of the bars and make sure others are deselected
+    all("#tabContentForTechnicalArea .ct-series-a .ct-bar")[1].click
+    count_bars = all("#tabContentForTechnicalArea .ct-series-a .ct-bar").count
+    count_deselected = all("#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected").count
+    assert(count_deselected == count_bars - 1)
+
+    ##
+    # reset and make sure no bar are deselected
+    find(".action-count-circle").click
+    count_deselected = all("#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected").count
+    assert(count_deselected == 0)
+
+    ##
+    # make sure Action Type tab has a legend
     find("#tabForActionType").click
     find("#tabContentForActionType .ct-legend").has_content?("Influenza specific")
 
+    ##
+    # click on one of the bars and make sure others are deselected
+    all("#tabContentForActionType .ct-series-b .ct-bar")[1].click
+    count_bars = all("#tabContentForActionType .ct-series-b .ct-bar").count
+    count_deselected = all("#tabContentForActionType .ct-series-b .ct-bar.ct-deselected").count
+    assert(count_deselected == count_bars - 1)
+
+    ##
+    # reset and make sure no bar are deselected
+    find(".action-count-circle").click
+    count_deselected = all("#tabContentForActionType .ct-series-b .ct-bar.ct-deselected").count
+    assert(count_deselected == 0)
+
+    ##
+    # go back to technical area tab
     find("#tabForTechnicalArea").click
 
     assert_selector("#technical-area-1") do


### PR DESCRIPTION
2 commits with 2 stories each:

Click on a bar segment makes inactive bars pale for chart by Technical Area [#172948679]
Click on orange action count restore color of inactive bar segments for chart by Technical Area [#172948760]

Click on a bar segment makes inactive bars pale for chart by Action Type [#172948681]
Click on orange action count restore color of inactive bar segments for chart by Action Type [#172948763]

Code changes include:
* Modify BarChartByTechnicalArea.js to receive state.ui.selectedTechnicalAreaId, and add a css class to inactive bars to make them pale when a bar is selected
* Modify BarChartByActionType.js to receive state.ui.selectedActionTypeOrdinal, and add a css class to inactive bars to make them pale when a bar is selected
* remove tooltips on re-render now that the bars are paying attention to state that can change
* Update unit and system tests

