### PR TITLE
Fix bug with layout of plan edit page on small and medium screens

### DIFF
--- a/app/javascript/src/components/List/Action.js
+++ b/app/javascript/src/components/List/Action.js
@@ -22,7 +22,7 @@ const Action = (props) => {
           <ActionBadgeDisease action={action} />
         )}
       </div>
-      <div className="col-8 col-lg-9">
+      <div className="col-12 col-lg-9">
         <strong>{indicator.display_abbreviation}</strong>
         &nbsp;
         <span className="action-text">{action.text}</span>


### PR DESCRIPTION
One small css change, just needed to make it be col-12 by default for the action text column for up to medium screens, no change to col-lg-9 for large and bigger screens

[#173902592]