### PR TITLE
Add a system test to verify that dropdown menu works in react and non-react contexts

### DIFF
--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -233,10 +233,25 @@ class AppsTest < ApplicationSystemTestCase
     find("#new_user input[type=submit]").trigger(:click)
 
     ##
-    # wind up on create account page
+    # make sure the plan was saved
     assert_current_path("/plans")
     assert page.has_content?("Welcome! You have signed up successfully.")
     assert page.has_content?("Saved Nigeria Plan 789") # ugh without this form field(s) dont get filled
+
+    ##
+    # make sure Turbolinks and the dropdown menu are working in both react and non-react contexts
+    click_on("WHO BENCHMARKS")
+    assert page.has_content?("BENCHMARKS FOR IHR CAPACITIES")
+    click_on("REFERENCE LIBRARY")
+    assert page.has_content?("Establishment of a Sentinel Laboratory-Based Antimicrobial Resistance Surveillance Network in Ethiopia")
+    click_on("email@example.com")
+    click_on("My Plans")
+    assert page.has_content?("Saved Nigeria Plan 789")
+    click_on("Saved Nigeria Plan 789")
+    assert page.has_content?("National Legislation, Policy and Financing")
+    click_on("email@example.com")
+    click_on("My Plans")
+    assert page.has_content?("Saved Nigeria Plan 789")
 
     ##
     # delete the plan


### PR DESCRIPTION
Add a system test to verify that dropdown menu works in react and non-react contexts
    
[#174131199]

This is related to work done in the following commits, and should catch any regressions if someone tries to change or optimized the way javascript packs are loaded

#7bd7dec9606f8fb17d99f6d7d1672782aa9c73b3
#fbcc2261c930be9ec4e4c2bea1d183a7cfe874de
