### PR TITLE
Save Plan when not logged in and hit the back button instead of logging in does not restore any changes made to the plan #173569175

### DIFF
--- a/app/javascript/src/components/PlanEditForm.js
+++ b/app/javascript/src/components/PlanEditForm.js
@@ -1,9 +1,11 @@
 import React from "react"
 import { useDispatch, useSelector } from "react-redux"
+import PropTypes from "prop-types"
 import ActionCount from "./ActionCount"
 import ChartCard from "./ChartCard/ChartCard"
 import ActionList from "./List/ActionList"
 import {
+  getPlan,
   getFormAuthenticityToken,
   getFormActionUrl,
   getPlanActionIds,
@@ -54,13 +56,20 @@ const setFormIsInvalid = function (formDomNode, submitDomNode) {
   formDomNode.classList.add("was-validated")
 }
 
-const PlanEditForm = () => {
+const updateStateFromServer = (stateToUpdateLater, plan, planActionIdsJson) => {
+  stateToUpdateLater.plan = JSON.stringify(plan)
+  stateToUpdateLater.planActionIds = planActionIdsJson
+}
+
+const PlanEditForm = (props) => {
   const formActionUrl = getFormActionUrl()
   const formAuthenticityToken = getFormAuthenticityToken()
   const dispatch = useDispatch()
-  const planNameFromStore = useSelector((state) => state.plan.name)
+  const plan = useSelector((state) => getPlan(state))
+  const planNameFromStore = plan.name
   const planActionIds = useSelector((state) => getPlanActionIds(state))
   const planActionIdsJson = JSON.stringify(planActionIds)
+  updateStateFromServer(props.stateToUpdateLater, plan, planActionIdsJson)
   return (
     <div className="row">
       <div className="col plan-container">
@@ -138,6 +147,10 @@ const PlanEditForm = () => {
       </div>
     </div>
   )
+}
+
+PlanEditForm.propTypes = {
+  stateToUpdateLater: PropTypes.object.isRequired,
 }
 
 export default PlanEditForm

--- a/app/javascript/src/components/PlanEditPage.js
+++ b/app/javascript/src/components/PlanEditPage.js
@@ -15,7 +15,7 @@ class PlanEditPage extends React.Component {
   render() {
     return (
       <Provider store={this.store}>
-        <PlanEditForm />
+        <PlanEditForm stateToUpdateLater={window.STATE_FROM_SERVER} />
       </Provider>
     )
   }

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -20,7 +20,6 @@
     "Radiation",
 ] %>
 
-<%#= react_component("PlanEditPage") %>
 <div data-react-class="PlanEditPage" data-react-props="{}" data-react-cache-id="PlanEditPage-0"></div>
 
 <%# the STATE_FROM_SERVER hash cannot end with ";" or else the JSON parser fails in save_state_from_server() %>
@@ -38,4 +37,9 @@
         "nudgesByActionType": <%= raw @nudges_by_action_type_json %>,
         "diseases": <%= raw @diseases.to_json %>
     };
+</script>
+<script type="application/javascript">
+  document.addEventListener('turbolinks:load', function () {
+    Turbolinks.clearCache()
+  });
 </script>


### PR DESCRIPTION
- the problem is that though the plan is in fact saved to the server/DB, the page re-renders its last known state
- add function updateStateFromServer to the PlanEditForm component to put state changes back into the DOM
- add event handler for turbolinks:load to clear Turbolinks' cache to help avoid page being re-rendered from Turbolinks cache