### PR TITLE
Do another pass on chart/nudge responsiveness #174217419

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -19,7 +19,9 @@
 }
 
 .info-pane-component {
-  min-width: 345px;
+  .row {
+    margin-bottom: 1em;
+  }
 }
 
 .action-count-component {
@@ -267,9 +269,9 @@
 
 .nudge-container {
   .nudge-left {
-    width: 260px;
     background-color: color("light-gray");
     border-right: 1px solid #eaeaeb;
+    word-break: break-word;
   }
   .nudge-tip-text {
     color: color("text-de-emphasized");

--- a/app/javascript/src/components/ChartCard/ActionCount.js
+++ b/app/javascript/src/components/ChartCard/ActionCount.js
@@ -8,7 +8,7 @@ const ActionCount = () => {
   )
 
   return (
-    <div className="col row action-count-component d-flex flex-column mb-4">
+    <div className="col-auto row action-count-component d-flex flex-column">
       <div className="col-auto count">{countOfPlanActionIds}</div>
       <div className="col-auto label">Actions</div>
     </div>

--- a/app/javascript/src/components/ChartCard/BarChartByActionType.js
+++ b/app/javascript/src/components/ChartCard/BarChartByActionType.js
@@ -11,6 +11,7 @@ import {
   getPlanActionIds,
   getPlanChartLabels,
   getSelectedActionTypeOrdinal,
+  getSelectedChartTabIndex,
 } from "../../config/selectors"
 
 class BarChartByActionType extends React.Component {
@@ -26,6 +27,7 @@ class BarChartByActionType extends React.Component {
       this.props.matrixOfActionCountsByActionTypeAndDisease,
       this.chartLabels
     )
+    this.updateChartSize()
     return (
       <div className="chart-container ct-chart-bar">
         <ChartistGraph
@@ -39,6 +41,31 @@ class BarChartByActionType extends React.Component {
         />
       </div>
     )
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.updateChartSize.bind(this))
+    window.addEventListener(
+      "orientationchange",
+      this.updateChartSize.bind(this)
+    )
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.updateChartSize.bind(this))
+    window.removeEventListener(
+      "orientationchange",
+      this.updateChartSize.bind(this)
+    )
+  }
+
+  // NB: the purpose of this method is to assist the chart in fitting into its container by simply calling chartist.update()
+  //   this is needed in these cases:
+  //   1) when selected tab is changed and chart re-renders, it will have been rendered too small due to having been in the hidden in the DOM
+  //   2) when the size of the window is changed (primarily for desktop-style web browsers)
+  //   3) when the orientation of the screen is changed thereby changing the size of the screen (primarily mobile-style web browsers: phones, tables, etc)
+  updateChartSize() {
+    setTimeout(() => this.chartistGraphInstance.chartist.update(), 0)
   }
 
   // TODO: refactor this and methods like it that perform non-React DOM operations/augmentation/manipulation to a module
@@ -201,6 +228,7 @@ const mapStateToProps = (state /*, ownProps*/) => {
       state
     ),
     selectedActionTypeOrdinal: getSelectedActionTypeOrdinal(state),
+    selectedChartTabIndex: getSelectedChartTabIndex(state),
   }
 }
 

--- a/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
+++ b/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
@@ -10,6 +10,7 @@ import {
   getAllTechnicalAreas,
   getMatrixOfActionCountsByTechnicalAreaAndDisease,
   getPlanChartLabels,
+  getSelectedChartTabIndex,
   getSelectedTechnicalAreaId,
 } from "../../config/selectors"
 
@@ -27,6 +28,7 @@ class BarChartByTechnicalArea extends React.Component {
       this.props.matrixOfActionCountsByTechnicalAreaAndDisease,
       chartLabels
     )
+    this.updateChartSize()
     return (
       <div className="chart-container ct-chart-bar">
         <ChartistGraph
@@ -40,6 +42,31 @@ class BarChartByTechnicalArea extends React.Component {
         />
       </div>
     )
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.updateChartSize.bind(this))
+    window.addEventListener(
+      "orientationchange",
+      this.updateChartSize.bind(this)
+    )
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.updateChartSize.bind(this))
+    window.removeEventListener(
+      "orientationchange",
+      this.updateChartSize.bind(this)
+    )
+  }
+
+  // NB: the purpose of this method is to assist the chart in fitting into its container by simply calling chartist.update()
+  //   this is needed in these cases:
+  //   1) when selected tab is changed and chart re-renders, it will have been rendered too small due to having been in the hidden in the DOM
+  //   2) when the size of the window is changed (primarily for desktop-style web browsers)
+  //   3) when the orientation of the screen is changed thereby changing the size of the screen (primarily mobile-style web browsers: phones, tables, etc)
+  updateChartSize() {
+    setTimeout(() => this.chartistGraphInstance.chartist.update(), 0)
   }
 
   getBarChartOptions(
@@ -209,6 +236,7 @@ const mapStateToProps = (state /*, ownProps*/) => {
     ),
     countActionsByTechnicalArea: countActionsByTechnicalArea(state),
     selectedTechnicalAreaId: getSelectedTechnicalAreaId(state),
+    selectedChartTabIndex: getSelectedChartTabIndex(state),
   }
 }
 

--- a/app/javascript/src/components/ChartCard/ChartCard.js
+++ b/app/javascript/src/components/ChartCard/ChartCard.js
@@ -56,18 +56,18 @@ const ChartCard = () => {
           id="tabContentForTechnicalArea"
           aria-labelledby="tabForTechnicalArea"
           role="tabpanel"
-          className="col-auto tab-pane fade show active"
+          className="col-auto tab-pane show active"
         >
           <div className="row no-gutters">
             {
               // Left Col
             }
-            <div className="chart-pane col d-flex flex-column align-items-center">
+            <div className="chart-pane col-12 col-xl-8 d-flex flex-column align-items-center">
               <h6 className="my-3">Actions per benchmark technical area</h6>
               {
                 // Actual Chart, by Technical Area
               }
-              <BarChartByTechnicalArea width="700" height="240" />
+              <BarChartByTechnicalArea width="100%" height="240" />
             </div>
 
             {
@@ -81,18 +81,18 @@ const ChartCard = () => {
           id="tabContentForActionType"
           aria-labelledby="tabForActionType"
           role="tabpanel"
-          className="col-auto tab-pane fade"
+          className="col-auto tab-pane"
         >
           <div className="row no-gutters">
             {
               // Left Col
             }
-            <div className="chart-pane col-12 col-lg d-flex mx-auto flex-column align-items-center">
+            <div className="chart-pane col-12 col-xl-8 d-flex flex-column align-items-center">
               <h6 className="my-3">Actions per action type</h6>
               {
                 // Actual Chart, by Action Type
               }
-              <BarChartByActionType width="700" height="240" />
+              <BarChartByActionType width="100%" height="240" />
             </div>
 
             {

--- a/app/javascript/src/components/ChartCard/ClearFilters.js
+++ b/app/javascript/src/components/ChartCard/ClearFilters.js
@@ -5,7 +5,7 @@ import { clearFilterCriteria } from "../../config/actions"
 const ClearFilters = () => {
   const dispatch = useDispatch()
   return (
-    <div className="col clear-filters-component d-flex justify-content-end">
+    <div className="col-auto clear-filters-component">
       <a
         href="#"
         title="Clear any filters applied"

--- a/app/javascript/src/components/ChartCard/InfluenzaToggle.js
+++ b/app/javascript/src/components/ChartCard/InfluenzaToggle.js
@@ -17,7 +17,7 @@ const InfluenzaToggle = () => {
   }
 
   return (
-    <div className="row d-flex flex-column mb-4">
+    <div className="row d-flex flex-column">
       <div className="col">
         <strong>Show diseases</strong>
       </div>

--- a/app/javascript/src/components/ChartCard/InfoPane.js
+++ b/app/javascript/src/components/ChartCard/InfoPane.js
@@ -11,8 +11,8 @@ import BarChartLegend from "./BarChartLegend"
 
 const InfoPane = () => {
   return (
-    <div className="info-pane-component col-12 col-xl-auto d-flex flex-column align-self-start">
-      <div className="row d-flex flex-row justify-content-between">
+    <div className="info-pane-component col-12 col-xl-4">
+      <div className="row d-flex justify-content-between">
         <ActionCount />
         <ClearFilters />
       </div>

--- a/app/javascript/src/components/Nudges/NudgeByActionType.js
+++ b/app/javascript/src/components/Nudges/NudgeByActionType.js
@@ -29,11 +29,11 @@ const NudgeByActionType = () => {
   ))
   return (
     <>
-      <div className="col-auto d-flex flex-column justify-content-center nudge-left">
+      <div className="col-4 col-lg-3 d-flex flex-column justify-content-center nudge-left">
         <div className="nudge-tip-text">Tips for</div>
         <h4 className="my-0">{nudgeData["action_type_name"]} actions</h4>
       </div>
-      <div className="col">
+      <div className="col-8 col-lg-9">
         <ul>{listItems}</ul>
       </div>
     </>
@@ -43,7 +43,7 @@ const NudgeByActionType = () => {
 const getNudgeContentZero = function () {
   return (
     <>
-      <div className="col-auto d-flex flex-column justify-content-center align-items-center nudge-left nudge-content-0">
+      <div className="col-4 col-lg-3 d-flex flex-column justify-content-center align-items-center nudge-left nudge-content-0">
         <div className="d-flex flex-column nudge-svg-box">
           <svg className="bar-chart" xmlns="http://www.w3.org/2000/svg">
             <path d="M20.8333 13.3333C21.1083 13.3333 21.3333 13.5583 21.3333 13.8333V15.5C21.3333 15.775 21.1083 16 20.8333 16H0.5C0.225 16 0 15.775 0 15.5V0.5C0 0.225 0.225 0 0.5 0H2.16667C2.44167 0 2.66667 0.225 2.66667 0.5V13.3333H20.8333ZM8 11.5V8.5C8 8.225 7.775 8 7.5 8H5.83333C5.55833 8 5.33333 8.225 5.33333 8.5V11.5C5.33333 11.775 5.55833 12 5.83333 12H7.5C7.775 12 8 11.775 8 11.5ZM16 11.5V5.83333C16 5.55833 15.775 5.33333 15.5 5.33333H13.8333C13.5583 5.33333 13.3333 5.55833 13.3333 5.83333V11.5C13.3333 11.775 13.5583 12 13.8333 12H15.5C15.775 12 16 11.775 16 11.5ZM12 11.5V3.16667C12 2.89167 11.775 2.66667 11.5 2.66667H9.83333C9.55833 2.66667 9.33333 2.89167 9.33333 3.16667V11.5C9.33333 11.775 9.55833 12 9.83333 12H11.5C11.775 12 12 11.775 12 11.5ZM20 11.5V1.83333C20 1.55833 19.775 1.33333 19.5 1.33333H17.8333C17.5583 1.33333 17.3333 1.55833 17.3333 1.83333V11.5C17.3333 11.775 17.5583 12 17.8333 12H19.5C19.775 12 20 11.775 20 11.5Z"></path>
@@ -53,10 +53,9 @@ const getNudgeContentZero = function () {
           </svg>
         </div>
       </div>
-      <div className="col mx-5 px-5">
+      <div className="col-8 col-lg-9">
         <h4>
-          Click on any bar in the chart to get tips on how to consolidate and
-          prioritize your plan.
+          Click on a bar to filter and to get tips for improving your plan.
         </h4>
       </div>
     </>

--- a/app/javascript/src/components/Nudges/NudgeByTechnicalArea.js
+++ b/app/javascript/src/components/Nudges/NudgeByTechnicalArea.js
@@ -13,11 +13,11 @@ const NudgeByTechnicalArea = () => {
   }
   return (
     <>
-      <div className="col-auto d-flex flex-column justify-content-center nudge-left">
+      <div className="col-4 col-lg-3 d-flex flex-column justify-content-center nudge-left">
         <div className="nudge-tip-text">Tips for</div>
         <h4 className="my-0">Your draft plan</h4>
       </div>
-      <div className="col">{whichNudgeComponent}</div>
+      <div className="col-8 col-lg-9">{whichNudgeComponent}</div>
     </>
   )
 }

--- a/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
@@ -8,6 +8,7 @@ import {
   getPlanActionIds,
   getPlanChartLabels,
   getSelectedActionTypeOrdinal,
+  getSelectedChartTabIndex,
 } from "config/selectors"
 
 jest.mock("config/selectors", () => ({
@@ -17,6 +18,7 @@ jest.mock("config/selectors", () => ({
   getPlanActionIds: jest.fn(),
   getPlanChartLabels: jest.fn(),
   getSelectedActionTypeOrdinal: jest.fn(),
+  getSelectedChartTabIndex: jest.fn(),
 }))
 
 it("BarChartByActionType has the expected 2 divs", () => {
@@ -29,6 +31,7 @@ it("BarChartByActionType has the expected 2 divs", () => {
   ])
   getPlanChartLabels.mockReturnValueOnce([["label1", "label2", "label3"], []])
   getSelectedActionTypeOrdinal.mockReturnValueOnce(null)
+  getSelectedChartTabIndex.mockReturnValueOnce(1)
 
   const renderedComponent = renderForConnect(
     <BarChartByActionType width="100%" height="240" />

--- a/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
@@ -8,6 +8,7 @@ import {
   getMatrixOfActionCountsByTechnicalAreaAndDisease,
   getPlanChartLabels,
   getSelectedTechnicalAreaId,
+  getSelectedChartTabIndex,
 } from "config/selectors"
 
 jest.mock("config/selectors", () => ({
@@ -17,6 +18,7 @@ jest.mock("config/selectors", () => ({
   getMatrixOfActionCountsByTechnicalAreaAndDisease: jest.fn(),
   getPlanChartLabels: jest.fn(),
   getSelectedTechnicalAreaId: jest.fn(),
+  getSelectedChartTabIndex: jest.fn(),
 }))
 
 it("BarChartByTechnicalArea has the expected 2 divs", () => {
@@ -29,8 +31,9 @@ it("BarChartByTechnicalArea has the expected 2 divs", () => {
   ])
   getPlanChartLabels.mockReturnValueOnce([["label1", "label2", "label3"], []])
   getSelectedTechnicalAreaId.mockReturnValueOnce(null)
+  getSelectedChartTabIndex.mockReturnValueOnce(0)
   const renderedComponent = renderForConnect(
-    <BarChartByTechnicalArea width="700" height="240" />
+    <BarChartByTechnicalArea width="100%" height="240" />
   )
   const container = renderedComponent.container
   const elComponentContainer = container.querySelectorAll(

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -12,7 +12,7 @@ class AppsTest < ApplicationSystemTestCase
     visit root_url
     click_on("Get Started")
 
-    sleep 0.1
+    sleep 0.2
     ##
     # navigate to Get Started page and submit its form
     assert_current_path("/get-started")
@@ -49,8 +49,8 @@ class AppsTest < ApplicationSystemTestCase
     # wind up on the View Plan page after the plan has been saved, and then make an edit
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal "Nigeria draft plan", find("#plan_name").value
-    assert page.has_content?("TOTAL ACTIONS")
-    assert_equal "235", find(".action-count-circle span").text
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "235", find(".action-count-component .count").text
     assert_selector("#technical-area-1") # the first one
     assert_selector("#technical-area-3") # the last one
     assert_selector(".nudge-container") do
@@ -71,7 +71,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_no_selector("#technical-area-1") # the first one
 
     # un-filter to show all
-    find(".action-count-circle").click
+    find(".clear-filters-component a").click
     assert_selector("#technical-area-1")
     assert_selector("#technical-area-18")
 
@@ -144,8 +144,8 @@ class AppsTest < ApplicationSystemTestCase
     # wind up on the View Plan page after the plan has been saved, and then make an edit
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal "Nigeria draft plan", find("#plan_name").value
-    assert page.has_content?("TOTAL ACTIONS")
-    assert_equal "283", find(".action-count-circle span").text
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "283", find(".action-count-component .count").text
     assert_selector("#technical-area-1") # the first one
     assert_selector("#technical-area-3") # the last one
     assert_selector(".nudge-container") do
@@ -168,7 +168,7 @@ class AppsTest < ApplicationSystemTestCase
 
     ##
     # reset and make sure no bar are deselected
-    find(".action-count-circle").click
+    find(".clear-filters-component a").click
     count_deselected = all("#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected").count
     assert(count_deselected == 0)
 
@@ -186,7 +186,7 @@ class AppsTest < ApplicationSystemTestCase
 
     ##
     # reset and make sure no bar are deselected
-    find(".action-count-circle").click
+    find(".clear-filters-component a").click
     count_deselected = all("#tabContentForActionType .ct-series-b .ct-bar.ct-deselected").count
     assert(count_deselected == 0)
 
@@ -212,7 +212,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_no_selector("#technical-area-1") # the first one
 
     # un-filter to show all
-    find(".action-count-circle").click
+    find(".clear-filters-component a").click
     assert_selector("#technical-area-1")
     assert_selector("#technical-area-18")
 
@@ -293,9 +293,9 @@ class AppsTest < ApplicationSystemTestCase
     # wind up on the View Plan page, make an edit, and save the plan
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal "Armenia draft plan", find("#plan_name").value
-    assert page.has_content?("TOTAL ACTIONS")
+    assert_equal "Actions", find(".action-count-component .label").text
     # action count was 103 but became 98 along with refactoring changes, I think due to bug(s) fixed
-    assert_equal "107", find(".action-count-circle span").text
+    assert_equal "107", find(".action-count-component .count").text
     assert page.has_content?(
              "Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors.",
            )
@@ -365,8 +365,8 @@ class AppsTest < ApplicationSystemTestCase
     # turn up on the View Plan, make an edit, save the plan
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal "Nigeria draft plan", find("#plan_name").value
-    assert page.has_content?("TOTAL ACTIONS")
-    assert_equal "28", find(".action-count-circle span").text
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "28", find(".action-count-component .count").text
     assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
@@ -383,7 +383,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     # un-filter to show all
-    find(".action-count-circle").click
+    find(".clear-filters-component a").click
     assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 


### PR DESCRIPTION
- modify the charts to update themselves on resize and tab-selection events, use new method updateChartSize
- remove the fade effect in the charts in order to clear the way for the size-updating stuff to work without the additional DOM async timing issues that fade brings with it.
- many CSS improvements and simplifications
- copy update of nudge zero state from Stacy
- update capybara system tests per the UI changes, all green.