### PR TITLE
Document why the JS packs and stylesheet downloads cannot be optimized further

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,26 @@ for the SPAR scores, there must a single spreadsheet with these columns:
 
 - update docs/object_diagram.png with the current object relationships
 - update this README with the latest, and remove cruft
+
+## A note on js packs and stylesheets
+
+You may notice a couple things that seem wasteful across the following files which reference this note:
+
+- `packs/base.js`
+- `packs/application.js`
+- `layouts/application.html.erb`
+- `helpers/application_helper.rb`
+
+First, there is both an `import "stylesheets/application.scss"` in `packs.base.js`
+and a `<%= stylesheet_pack_tag 'application', media: 'all' %>` in `layouts/application.html.erb`.
+
+If you remove `<%= stylesheet_pack_tag 'application', media: 'all' %>` you will get no styling.
+
+If you remove `import "stylesheets/application.scss"` you will get no tootips due to a JS error `tooltip is not a function`.
+
+Second, you might think you could load `packs/base.js` on every page and remove the `import "./base"` at
+the top of `packs/application.js`, so that you are not effectively loading `base.js` twice.
+
+If you remove this import you will again get the JS error `tooltip is not a function`.
+
+This is as optimized as we have been able to get the packs download sizes at this time and still maintain functionality on all pages.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,8 @@ module ApplicationHelper
   #   to Google Lighthouse tools) BUT there is a flash of unstyled
   #   content on those pages. We decided to go with slightly slower (~1s)
   #   to be more "correct".
+  #
+  # NB: please refer to the section in README.md ## A note on js packs and stylesheets
   def which_js
     if is_homepage?
       javascript_pack_tag 'basic', "data-turbolinks-track": "reload"

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,3 +1,4 @@
+// NB: please refer to the section in README.md ## A note on js packs and stylesheets
 import "./base"
 
 // stimulus polyfill must be loaded first, also needed for IE 10 to work properly

--- a/app/javascript/packs/base.js
+++ b/app/javascript/packs/base.js
@@ -7,6 +7,8 @@ import "regenerator-runtime/runtime"
 //   how you can access it. This does not increase size of JS?
 import $ from "jquery" //eslint-disable-line
 import "bootstrap"
+
+// NB: please refer to the section in README.md ## A note on js packs and stylesheets
 import "stylesheets/application.scss"
 
 import Turbolinks from "turbolinks"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><%#= this meta tag is per Bootstrap: https://getbootstrap.com/docs/4.4/getting-started/introduction/  %>
+    <%# NB: please refer to the section in README.md ## A note on js packs and stylesheets %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= which_js %>
   </head>


### PR DESCRIPTION
This started out as a chore to further optimize the JS download sizes across pages, but instead turned into documentation of the hard won knowledge as to why you can't optimize it further at this time.

See section at end of README.md, and references to this in the 4 files.

[#174236913]
