### PR TITLE
Fix for IE in React Land #174242259

### DIFF
--- a/app/javascript/src/components/ChartCard/BarChartByActionType.js
+++ b/app/javascript/src/components/ChartCard/BarChartByActionType.js
@@ -13,6 +13,7 @@ import {
   getSelectedActionTypeOrdinal,
   getSelectedChartTabIndex,
 } from "../../config/selectors"
+import { offsetTheChartSegmentLabelsForIE } from "./ChartFixesForIE"
 
 class BarChartByActionType extends React.Component {
   constructor(props) {
@@ -65,10 +66,14 @@ class BarChartByActionType extends React.Component {
   //   2) when the size of the window is changed (primarily for desktop-style web browsers)
   //   3) when the orientation of the screen is changed thereby changing the size of the screen (primarily mobile-style web browsers: phones, tables, etc)
   updateChartSize() {
-    setTimeout(() => this.chartistGraphInstance.chartist.update(), 0)
+    setTimeout(() => {
+      this.chartistGraphInstance.chartist.update()
+      offsetTheChartSegmentLabelsForIE(
+        this.chartistGraphInstance.chartist.container
+      )
+    }, 0)
   }
 
-  // TODO: refactor this and methods like it that perform non-React DOM operations/augmentation/manipulation to a module
   getBarChartOptions(
     countActionsByActionType,
     matrixOfActionCountsByActionTypeAndDisease,
@@ -122,6 +127,7 @@ class BarChartByActionType extends React.Component {
     seriesB.removeClass("ct-deselected")
 
     this.cleanupTooltipsFromPreviousRender()
+    offsetTheChartSegmentLabelsForIE(domNode)
 
     for (let i = 0; i < countActionsByActionType.length; i++) {
       const objOfActionCounts = {

--- a/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
+++ b/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
@@ -13,6 +13,7 @@ import {
   getSelectedChartTabIndex,
   getSelectedTechnicalAreaId,
 } from "../../config/selectors"
+import { offsetTheChartSegmentLabelsForIE } from "./ChartFixesForIE"
 
 class BarChartByTechnicalArea extends React.Component {
   constructor(props) {
@@ -66,7 +67,12 @@ class BarChartByTechnicalArea extends React.Component {
   //   2) when the size of the window is changed (primarily for desktop-style web browsers)
   //   3) when the orientation of the screen is changed thereby changing the size of the screen (primarily mobile-style web browsers: phones, tables, etc)
   updateChartSize() {
-    setTimeout(() => this.chartistGraphInstance.chartist.update(), 0)
+    setTimeout(() => {
+      this.chartistGraphInstance.chartist.update()
+      offsetTheChartSegmentLabelsForIE(
+        this.chartistGraphInstance.chartist.container
+      )
+    }, 0)
   }
 
   getBarChartOptions(
@@ -121,6 +127,7 @@ class BarChartByTechnicalArea extends React.Component {
     seriesB.removeClass("ct-deselected")
 
     this.cleanupTooltipsFromPreviousRender()
+    offsetTheChartSegmentLabelsForIE(domNode)
 
     for (let i = 0; i < technicalAreas.length; i++) {
       const objOfActionCounts = {

--- a/app/javascript/src/components/ChartCard/ChartFixesForIE.js
+++ b/app/javascript/src/components/ChartCard/ChartFixesForIE.js
@@ -1,0 +1,66 @@
+//
+// The problem: needed a method to detect IE 10 and 11 for the purpose of working around an IE-specific
+//   issue, namely what the offsetTheChartSegmentLabelsForIE method addresses.
+//
+// Attempted solutions: First I tried to use Modernizr https://modernizr.com/ to take a
+//   feature-detection approach to working around the issue (as opposed to browser detection, which is not as
+//   good as a feature detection approach). At the time I tried it, Modernizr offered no detector for CSS transforms
+//   for SVG. The closest thing I found was this issue on the Modernizr repo which is still
+//   open/unmerged/unresolved: https://github.com/Modernizr/Modernizr/issues/1985
+//   Also looked into 3rd party libraries to handle this, most of which check the user agent string which is known to
+//   be an imperfect method, and would have required us to add yet another 3rd party library which we would rather avoid anyways.
+//
+// The solution: a browser detection technique via `document.documentMode` which is present on
+//   MS Internet Explorer 6 - 11 which is sufficient for this purpose. We actually just wanted to target IE 10-11
+//  but this is fine: its a simple and reliable detection method and does not require the addition of any additional code/libraries.
+//
+import $ from "jquery"
+
+const isIE = () => {
+  return !!document.documentMode
+}
+
+//
+// The problem: IE does not support CSS transforms on SVG elements, which is what we used to get those
+//   bar chart segment labels rendered at a 45º angle in modern web browsers. That does not work in IE 10/11.
+//
+// Attempted solutions: tried to do this in CSS which would have been better and easier with the IE-specific
+//  stylesheet that we already have, but could not get these offsets to take effect via CSS for IE.
+//
+// The solution: In conjunction with the writing mode change in the IE-specific stylesheet to render these
+//   elements sideways at 90º, apply X and Y offsets here via JavaScript to the SVG nodes (TEXT nodes in IE).
+//   The offsets are arbitrary, just what aligned with the bar chart segments in IE 11 and looked decent on IE 11.
+//
+const offsetTheChartSegmentLabelsForIE = (chartistDomContainer) => {
+  if (!isIE() || !chartistDomContainer) {
+    return
+  }
+
+  const chartLabelEls = chartistDomContainer.querySelectorAll(
+    ".ct-label.ct-horizontal"
+  )
+  const chartBarEls = chartistDomContainer.querySelectorAll("line.ct-bar")
+  chartLabelEls.forEach((chartLabelEl, idx) => {
+    const offsetX = -4
+    const offsetY = 5
+    const $chartLabelEl = $(chartLabelEl)
+    const barXcoord = parseInt($(chartBarEls[idx]).attr("x1"))
+    const barYcoord = parseInt($(chartBarEls[idx]).attr("y1"))
+    $chartLabelEl.attr("x", barXcoord + offsetX).attr("y", barYcoord + offsetY)
+  })
+}
+
+//
+// The problem: IE does not support CSS transforms on SVG elements
+//
+// The solution: Set the SVG PATH node's transform attribute via JS
+//
+const sizeTheSvgForIE = () => {
+  if (!isIE()) {
+    return
+  }
+
+  $("svg.bar-chart path").attr("transform", "scale(2.5)")
+}
+
+export { isIE, offsetTheChartSegmentLabelsForIE, sizeTheSvgForIE }

--- a/app/javascript/src/components/Nudges/NudgeByActionType.js
+++ b/app/javascript/src/components/Nudges/NudgeByActionType.js
@@ -5,6 +5,7 @@ import {
   getSelectedActionTypeOrdinal,
   countActionsByActionType,
 } from "../../config/selectors"
+import { sizeTheSvgForIE } from "../ChartCard/ChartFixesForIE"
 
 const NudgeByActionType = () => {
   const nudgesByActionType = useSelector((state) =>
@@ -41,6 +42,7 @@ const NudgeByActionType = () => {
 }
 
 const getNudgeContentZero = function () {
+  setTimeout(sizeTheSvgForIE, 10)
   return (
     <>
       <div className="col-4 col-lg-3 d-flex flex-column justify-content-center align-items-center nudge-left nudge-content-0">


### PR DESCRIPTION
- add new module ChartFixesForIE to contain the JS fixes for IE (11) whose code is cannibalized from the legacy JS code of this app
- make use of the offsetTheChartSegmentLabelsForIE method in chart components where rendering/resizing occurs
- modify the algo in offsetTheChartSegmentLabelsForIE to position the labels relative to the bars which works better for the varied responsive screen sizes this page supports
- make use of sizeTheSvgForIE to properly up size the bar chart icon for IE which is used in the "nudge zero" state of the chart by Action Type
- remove obsolete comment