### PR TITLE
Setup Semaphore 2.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: Test MyApp
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Test
+    task:
+      env_vars:
+        - name: DATABASE_URL
+          value: "postgresql://postgres:@0.0.0.0:5432/myapp_test"
+        - name: RAILS_ENV
+          value: test
+      jobs:
+      - name: Test
+        commands:
+          - checkout
+          - sem-service start postgres 11
+          - sem-version ruby 2.6.5
+          - cache restore
+          - bundle install --deployment --path vendor/bundle
+          - cache store
+          - bundle exec rake db:setup
+          - bundle exec rspec

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,12 +37,10 @@ blocks:
       - name: JS tests
         commands:
           - checkout
-          - sem-version ruby 2.6.5
           - sem-version node 12.16.3
           - cache restore
-          - bundle install --deployment --path vendor/bundle
           - yarn install --frozen-lockfile --check-files
-          - bundle exec rake test:js
+          - yarn test
       - name: System tests
         commands:
           - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,14 +17,11 @@ blocks:
       - name: eslint
         commands:
           - checkout
-          - sem-version ruby 2.6.3
           - sem-version node 14.7.0
           - cache restore
-          - bundle install --deployment --path vendor/bundle
           - yarn install --frozen-lockfile --check-files
-          - cache store
           - npx eslint app
-      - name: Unit tests
+      - name: Ruby tests
         commands:
           - checkout
           - sem-service start postgres 11
@@ -40,15 +37,11 @@ blocks:
       - name: JS tests
         commands:
           - checkout
-          - sem-service start postgres 11
           - sem-version ruby 2.6.5
           - sem-version node 12.16.3
           - cache restore
           - bundle install --deployment --path vendor/bundle
           - yarn install --frozen-lockfile --check-files
-          - cache store
-          - bundle exec rake db:setup
-          - bundle exec rake db:test:prepare
           - bundle exec rake test:js
       - name: System tests
         commands:
@@ -59,7 +52,6 @@ blocks:
           - cache restore
           - bundle install --deployment --path vendor/bundle
           - yarn install --frozen-lockfile --check-files
-          - cache store
           - bundle exec rake db:setup
           - bundle exec rake db:test:prepare
           - bundle exec rake test:system

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,11 +10,11 @@ blocks:
     task:
       env_vars:
         - name: DATABASE_URL
-          value: "postgresql://postgres:@0.0.0.0:5432/myapp_test"
+          value: "postgresql://postgres:@0.0.0.0:5432/benchmarks_test"
         - name: RAILS_ENV
           value: test
       jobs:
-      - name: Test
+      - name: Unit tests
         commands:
           - checkout
           - sem-service start postgres 11
@@ -27,5 +27,29 @@ blocks:
           - bundle exec rake db:setup
           - bundle exec rake db:test:prepare
           - bundle exec rake test
+      - name: JS tests
+        commands:
+          - checkout
+          - sem-service start postgres 11
+          - sem-version ruby 2.6.5
+          - sem-version node 12.16.3
+          - cache restore
+          - bundle install --deployment --path vendor/bundle
+          - yarn install --frozen-lockfile --check-files
+          - cache store
+          - bundle exec rake db:setup
+          - bundle exec rake db:test:prepare
           - bundle exec rake test:js
+      - name: System tests
+        commands:
+          - checkout
+          - sem-service start postgres 11
+          - sem-version ruby 2.6.5
+          - sem-version node 12.16.3
+          - cache restore
+          - bundle install --deployment --path vendor/bundle
+          - yarn install --frozen-lockfile --check-files
+          - cache store
+          - bundle exec rake db:setup
+          - bundle exec rake db:test:prepare
           - bundle exec rake test:system

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,8 +17,8 @@ blocks:
       - name: eslint
         commands:
           - checkout
-          - sem-version ruby 2.6.5
-          - sem-version node 12.16.3
+          - sem-version ruby 2.6.3
+          - sem-version node 14.7.0
           - cache restore
           - bundle install --deployment --path vendor/bundle
           - yarn install --frozen-lockfile --check-files

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Test MyApp
+name: benchmarks
 agent:
   machine:
     type: e1-standard-2
@@ -19,8 +19,13 @@ blocks:
           - checkout
           - sem-service start postgres 11
           - sem-version ruby 2.6.5
+          - sem-version node 12.16.3
           - cache restore
           - bundle install --deployment --path vendor/bundle
+          - yarn install --frozen-lockfile --check-files
           - cache store
           - bundle exec rake db:setup
-          - bundle exec rspec
+          - bundle exec rake db:test:prepare
+          - bundle exec rake test
+          - bundle exec rake test:js
+          - bundle exec rake test:system

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,6 +14,16 @@ blocks:
         - name: RAILS_ENV
           value: test
       jobs:
+      - name: eslint
+        commands:
+          - checkout
+          - sem-version ruby 2.6.5
+          - sem-version node 12.16.3
+          - cache restore
+          - bundle install --deployment --path vendor/bundle
+          - yarn install --frozen-lockfile --check-files
+          - cache store
+          - npx eslint app
       - name: Unit tests
         commands:
           - checkout

--- a/test/javascript/setup.js
+++ b/test/javascript/setup.js
@@ -16,3 +16,14 @@ const script = window.document.createElement("script")
 script.textContent = shim
 
 window.document.body.appendChild(script)
+
+// polyfill matchMedia for Jest
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {},
+    }
+  }

--- a/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByActionType.test.js
@@ -10,6 +10,7 @@ import {
   getSelectedActionTypeOrdinal,
   getSelectedChartTabIndex,
 } from "config/selectors"
+import "bootstrap"
 
 jest.mock("config/selectors", () => ({
   countActionsByActionType: jest.fn(),

--- a/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
@@ -11,6 +11,8 @@ import {
   getSelectedChartTabIndex,
 } from "config/selectors"
 
+$.fn.tooltip = jest.fn()
+
 jest.mock("config/selectors", () => ({
   countActionsByTechnicalArea: jest.fn(),
   getAllActions: jest.fn(),

--- a/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartByTechnicalArea.test.js
@@ -10,8 +10,7 @@ import {
   getSelectedTechnicalAreaId,
   getSelectedChartTabIndex,
 } from "config/selectors"
-
-$.fn.tooltip = jest.fn()
+import "bootstrap"
 
 jest.mock("config/selectors", () => ({
   countActionsByTechnicalArea: jest.fn(),


### PR DESCRIPTION
Lets us run CI on Semaphore 2.0 instead of 1.0. We might need to adjust the repo checks, or remove Semaphore 1.0, after merging this?