### PR TITLE
Always show disease-specific actions if selected [#177258262]

### DIFF
--- a/app/javascript/src/components/List/IndicatorActionList.js
+++ b/app/javascript/src/components/List/IndicatorActionList.js
@@ -30,9 +30,8 @@ const IndicatorActionList = (props) => {
   const planDiseases = useSelector((state) => getPlanDiseases(state))
   let actionsForIndicator = getActionsForIds(actionIdsByIndicator, actions)
 
-  if (!goalForThisIndicator) {
-    return <NoGoalForThisIndicator />
-  }
+  const noGoalForThisIndicator =
+    goalForThisIndicator.value === null ? <NoGoalForThisIndicator /> : null
 
   const sortedActionsByIndicator = getSortedActions(
     actionsForIndicator,
@@ -54,6 +53,7 @@ const IndicatorActionList = (props) => {
 
   return (
     <>
+      {noGoalForThisIndicator}
       {actionGeneralComponents}
       {actionDiseaseComponents}
       <AddAction indicator={indicator} />

--- a/app/javascript/src/components/List/NoGoalForThisIndicator.js
+++ b/app/javascript/src/components/List/NoGoalForThisIndicator.js
@@ -2,7 +2,7 @@ import React from "react"
 
 const NoGoalForThisIndicator = () => {
   return (
-    <div className="row p-3 no-actions">
+    <div className="row p-3 no-capacity-gap">
       <div className="col font-italic">
         There is no capacity gap for actions. You should review the Benchmarks
         document to ensure you have completed the tasks up to this level.

--- a/app/models/concerns/plan_builder.rb
+++ b/app/models/concerns/plan_builder.rb
@@ -27,7 +27,9 @@ module PlanBuilder
 
   module ClassMethods
     def new_from_assessment(
-      assessment:, is_5_year_plan: false, technical_area_ids: nil
+      assessment:,
+      is_5_year_plan: false,
+      technical_area_ids: nil
     )
       plan_term =
         is_5_year_plan ? Plan::TERM_TYPES.second : Plan::TERM_TYPES.first
@@ -35,17 +37,19 @@ module PlanBuilder
         Plan.new(
           assessment: assessment,
           name: "#{assessment.country.name} draft plan",
-          term: plan_term,
+          term: plan_term
         )
       assessment_publication = assessment.assessment_publication
       assessment_technical_areas =
         if technical_area_ids.present? && technical_area_ids.any?
-          assessment_publication.assessment_technical_areas.includes(
-            :assessment_indicators,
-          ).where(id: technical_area_ids).all
+          assessment_publication
+            .assessment_technical_areas
+            .includes(:assessment_indicators)
+            .where(id: technical_area_ids)
+            .all
         else
           assessment_publication.assessment_technical_areas.includes(
-            :assessment_indicators,
+            :assessment_indicators
           )
         end
       assessment_indicators =
@@ -79,94 +83,70 @@ module PlanBuilder
       disease_ids: [],
       user: nil
     )
-      num_of_underscores = assessment.spar_2018? ? 3 : 2
-      named_ids =
-        indicator_attrs.select do |k, _|
-          k.count("_").eql?(num_of_underscores)
-        end.keys
-      scores_and_goals_by_named_id = {}
-      named_ids.each do |named_id|
-        scores_and_goals_by_named_id[named_id] = {
-          score: indicator_attrs[named_id].to_i,
-          goal: indicator_attrs[named_id + "_goal"].to_i,
-        }
-      end
+      named_ids = create_named_ids(assessment, indicator_attrs)
+      scores_and_goals_by_named_id =
+        create_scores_and_goals(named_ids, indicator_attrs)
       plan_term =
         is_5_year_plan ? Plan::TERM_TYPES.second : Plan::TERM_TYPES.first
+      disease_action_map = create_disease_actions_map(disease_ids)
+      plan_goals = []
+      plan_actions = []
+
       plan =
         Plan.new(
           {
-            name: plan_name, assessment: assessment, term: plan_term, user: user
-          },
+            name: plan_name,
+            assessment: assessment,
+            term: plan_term,
+            user: user
+          }
         )
-      # fetch disease-specific actions for all of the selected IDs in one query
-      disease_actions = BenchmarkIndicatorAction.where(disease_id: disease_ids).all
-      # build a "disease-action" map of benchmarkIndicatorID => Action so that it can be used in the loop of BenchmarkIndicators
-      disease_action_map = disease_actions.reduce({}) do |acc, action|
-        if acc[action.benchmark_indicator_id.to_s].nil?
-          acc[action.benchmark_indicator_id.to_s] = []
-        end
-        acc[action.benchmark_indicator_id.to_s] << action
-        acc
-      end
-      plan_goals = []
-      plan_actions = []
+
       assessment_indicators =
-        AssessmentIndicator.includes(
-          { benchmark_indicators: :benchmark_technical_area },
-        ).where(named_id: named_ids).distinct.all
+        AssessmentIndicator
+          .includes({ benchmark_indicators: :benchmark_technical_area })
+          .distinct
+          .all
+
       assessment_indicators.each do |assessment_indicator|
         score_and_goal =
           scores_and_goals_by_named_id[assessment_indicator.named_id]
-        goal_value = score_and_goal[:goal]
+        goal_value = score_and_goal.present? ? score_and_goal[:goal] : nil
         benchmark_indicators = assessment_indicator.benchmark_indicators.uniq
         benchmark_indicators.each do |benchmark_indicator|
-          already_seen_indicator =
-            plan_goals.any? do |pbi|
-              pbi.benchmark_indicator.id.eql?(benchmark_indicator.id)
-            end
-          unless already_seen_indicator
+          unless update_maybe_seen_indicator(
+                   plan_goals,
+                   benchmark_indicator,
+                   goal_value
+                 )
             plan_goals <<
               PlanGoal.new(
                 plan: plan,
                 assessment_indicator: assessment_indicator,
                 benchmark_indicator: benchmark_indicator,
-                value: goal_value,
+                value: goal_value
               )
           end
           bia =
-            benchmark_indicator.actions.where(
-              "level > :score AND level <= :goal",
+            get_bia_actions(
               score_and_goal,
-            ).order(:sequence).all
-          # use disease_action_map to append its Action(s) to the matching Indicator when the disease-specific action.benchmark_indicator_id
-          #   matches the current benchmark_indicator.id
-          disease_actions_for_indicator = disease_action_map[benchmark_indicator.id.to_s]
-          if disease_actions_for_indicator.present?
-            bia += disease_actions_for_indicator
-          end
+              benchmark_indicator,
+              disease_action_map
+            )
           bia.each do |benchmark_indicator_action|
-            unless plan_actions.any? do |pa|
-                     pa.benchmark_indicator_action_id.eql?(
-                       benchmark_indicator_action.id,
-                     )
-                   end
-              plan_actions <<
-                PlanAction.new(
-                  plan: plan,
-                  benchmark_indicator_action: benchmark_indicator_action,
-                  benchmark_indicator: benchmark_indicator,
-                  benchmark_technical_area:
-                    benchmark_indicator.benchmark_technical_area,
-                )
-            end
+            add_plan_actions_to_indicator(
+              plan_actions,
+              plan,
+              benchmark_indicator,
+              benchmark_indicator_action
+            )
           end
         end
       end
 
       begin
         plan.disease_ids = disease_ids
-      rescue ActiveRecord::RecordNotFound =>  e
+      rescue ActiveRecord::RecordNotFound => e
         raise Exceptions::InvalidDiseasesError
       end
 
@@ -176,6 +156,96 @@ module PlanBuilder
         plan.save!
       end
       plan
+    end
+
+    def create_named_ids(assessment, indicator_attrs)
+      num_of_underscores = assessment.spar_2018? ? 3 : 2
+      indicator_attrs.select do |k, _|
+        k.count('_').eql?(num_of_underscores)
+      end.keys
+    end
+
+    def create_scores_and_goals(named_ids, indicator_attrs)
+      scores_and_goals_by_named_id = {}
+      named_ids.each do |named_id|
+        scores_and_goals_by_named_id[named_id] = {
+          score: indicator_attrs[named_id].to_i,
+          goal: indicator_attrs[named_id + '_goal'].to_i
+        }
+      end
+      scores_and_goals_by_named_id
+    end
+
+    def create_disease_actions_map(disease_ids)
+      # fetch disease-specific actions for all of the selected IDs in one query
+      disease_actions =
+        BenchmarkIndicatorAction.where(disease_id: disease_ids).all
+
+      # build a "disease-action" map of benchmarkIndicatorID => Action so that it can be used in the loop of BenchmarkIndicators
+      disease_actions.reduce({}) do |acc, action|
+        if acc[action.benchmark_indicator_id.to_s].nil?
+          acc[action.benchmark_indicator_id.to_s] = []
+        end
+        acc[action.benchmark_indicator_id.to_s] << action
+        acc
+      end
+    end
+
+    def update_maybe_seen_indicator(plan_goals, benchmark_indicator, goal_value)
+      plan_goals.any? do |pbi|
+        if pbi.benchmark_indicator.id.eql?(benchmark_indicator.id)
+          pbi.value = goal_value unless goal_value.nil?
+          true
+        end
+      end
+    end
+
+    def get_bia_actions(score_and_goal, benchmark_indicator, disease_action_map)
+      if score_and_goal.present?
+        bia =
+          benchmark_indicator
+            .actions
+            .where('level > :score AND level <= :goal', score_and_goal)
+            .order(:sequence)
+            .all
+
+        # use disease_action_map to append its Action(s) to the matching Indicator when the disease-specific action.benchmark_indicator_id
+        #   matches the current benchmark_indicator.id
+        disease_actions_for_indicator =
+          disease_action_map[benchmark_indicator.id.to_s]
+        bia += disease_actions_for_indicator if disease_actions_for_indicator
+          .present?
+      else
+        bia =
+          benchmark_indicator
+            .actions
+            .where('disease_id IS NOT NULL')
+            .order(:sequence)
+            .all
+      end
+      bia
+    end
+
+    def add_plan_actions_to_indicator(
+      plan_actions,
+      plan,
+      benchmark_indicator,
+      benchmark_indicator_action
+    )
+      unless plan_actions.any? do |pa|
+               pa.benchmark_indicator_action_id.eql?(
+                 benchmark_indicator_action.id
+               )
+             end
+        plan_actions <<
+          PlanAction.new(
+            plan: plan,
+            benchmark_indicator_action: benchmark_indicator_action,
+            benchmark_indicator: benchmark_indicator,
+            benchmark_technical_area:
+              benchmark_indicator.benchmark_technical_area
+          )
+      end
     end
   end
 end

--- a/db/migrate/20210311221558_remove_null_constraint_from_plan_goals_value.rb
+++ b/db/migrate/20210311221558_remove_null_constraint_from_plan_goals_value.rb
@@ -1,0 +1,9 @@
+class RemoveNullConstraintFromPlanGoalsValue < ActiveRecord::Migration[5.2]
+  def up
+    change_column :plan_goals, :value, :integer, null: true
+  end
+
+  def down
+    change_column :plan_goals, :value, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,186 +10,206 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_215134) do
-
+ActiveRecord::Schema.define(version: 2021_03_11_221558) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "assessment_indicators", force: :cascade do |t|
-    t.integer "assessment_technical_area_id"
-    t.string "named_id", limit: 20
-    t.integer "sequence"
-    t.string "text", limit: 500
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_technical_area_id"], name: "index_assessment_indicators_on_assessment_technical_area_id"
+  create_table 'assessment_indicators', force: :cascade do |t|
+    t.integer 'assessment_technical_area_id'
+    t.string 'named_id', limit: 20
+    t.integer 'sequence'
+    t.string 'text', limit: 500
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['assessment_technical_area_id'],
+            name: 'index_assessment_indicators_on_assessment_technical_area_id'
   end
 
-  create_table "assessment_indicators_benchmark_indicators", id: false, force: :cascade do |t|
-    t.integer "assessment_indicator_id"
-    t.integer "benchmark_indicator_id"
-    t.index ["assessment_indicator_id", "benchmark_indicator_id"], name: "BI_to_EI_each_pair_must_be_unique", unique: true
-    t.index ["assessment_indicator_id"], name: "BI_to_EI_assessment_indicator_id"
-    t.index ["benchmark_indicator_id"], name: "BI_to_EI_benchmark_indicator_id"
+  create_table 'assessment_indicators_benchmark_indicators',
+               id: false,
+               force: :cascade do |t|
+    t.integer 'assessment_indicator_id'
+    t.integer 'benchmark_indicator_id'
+    t.index %w[assessment_indicator_id benchmark_indicator_id],
+            name: 'BI_to_EI_each_pair_must_be_unique',
+            unique: true
+    t.index ['assessment_indicator_id'],
+            name: 'BI_to_EI_assessment_indicator_id'
+    t.index ['benchmark_indicator_id'], name: 'BI_to_EI_benchmark_indicator_id'
   end
 
-  create_table "assessment_publications", force: :cascade do |t|
-    t.string "title", limit: 200
-    t.string "named_id", limit: 10
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "abbrev", limit: 10
-    t.string "revision", limit: 10
-    t.index ["named_id"], name: "index_assessment_publications_on_named_id"
+  create_table 'assessment_publications', force: :cascade do |t|
+    t.string 'title', limit: 200
+    t.string 'named_id', limit: 10
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'abbrev', limit: 10
+    t.string 'revision', limit: 10
+    t.index ['named_id'], name: 'index_assessment_publications_on_named_id'
   end
 
-  create_table "assessment_scores", force: :cascade do |t|
-    t.integer "assessment_id", null: false
-    t.integer "assessment_indicator_id", null: false
-    t.integer "value", null: false
+  create_table 'assessment_scores', force: :cascade do |t|
+    t.integer 'assessment_id', null: false
+    t.integer 'assessment_indicator_id', null: false
+    t.integer 'value', null: false
   end
 
-  create_table "assessment_technical_areas", force: :cascade do |t|
-    t.integer "assessment_publication_id"
-    t.string "named_id", limit: 20
-    t.integer "sequence"
-    t.string "text", limit: 200
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_publication_id"], name: "index_assessment_technical_areas_on_assessment_publication_id"
+  create_table 'assessment_technical_areas', force: :cascade do |t|
+    t.integer 'assessment_publication_id'
+    t.string 'named_id', limit: 20
+    t.integer 'sequence'
+    t.string 'text', limit: 200
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['assessment_publication_id'],
+            name:
+              'index_assessment_technical_areas_on_assessment_publication_id'
   end
 
-  create_table "assessments", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "country_alpha3", limit: 3
-    t.integer "assessment_publication_id"
+  create_table 'assessments', force: :cascade do |t|
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'country_alpha3', limit: 3
+    t.integer 'assessment_publication_id'
   end
 
-  create_table "benchmark_indicator_actions", force: :cascade do |t|
-    t.integer "benchmark_indicator_id"
-    t.string "text", limit: 1000
-    t.integer "level"
-    t.integer "sequence"
-    t.integer "action_types", default: [], array: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "disease_id"
-    t.index ["benchmark_indicator_id"], name: "index_benchmark_indicator_actions_on_benchmark_indicator_id"
+  create_table 'benchmark_indicator_actions', force: :cascade do |t|
+    t.integer 'benchmark_indicator_id'
+    t.string 'text', limit: 1000
+    t.integer 'level'
+    t.integer 'sequence'
+    t.integer 'action_types', default: [], array: true
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'disease_id'
+    t.index ['benchmark_indicator_id'],
+            name: 'index_benchmark_indicator_actions_on_benchmark_indicator_id'
   end
 
-  create_table "benchmark_indicators", force: :cascade do |t|
-    t.integer "benchmark_technical_area_id"
-    t.integer "sequence"
-    t.string "display_abbreviation", limit: 10
-    t.string "text", limit: 500
-    t.string "objective", limit: 500
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["benchmark_technical_area_id"], name: "index_benchmark_indicators_on_benchmark_technical_area_id"
+  create_table 'benchmark_indicators', force: :cascade do |t|
+    t.integer 'benchmark_technical_area_id'
+    t.integer 'sequence'
+    t.string 'display_abbreviation', limit: 10
+    t.string 'text', limit: 500
+    t.string 'objective', limit: 500
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['benchmark_technical_area_id'],
+            name: 'index_benchmark_indicators_on_benchmark_technical_area_id'
   end
 
-  create_table "benchmark_technical_areas", force: :cascade do |t|
-    t.string "text", limit: 200
-    t.integer "sequence"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'benchmark_technical_areas', force: :cascade do |t|
+    t.string 'text', limit: 200
+    t.integer 'sequence'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "countries", force: :cascade do |t|
-    t.string "name", limit: 100
-    t.string "alpha2", limit: 2
-    t.string "alpha3", limit: 3
-    t.string "country_code", limit: 3
-    t.string "region", limit: 50
-    t.string "sub_region", limit: 50
-    t.string "intermediate_region", limit: 50
-    t.string "region_code", limit: 3
-    t.string "sub_region_code", limit: 3
-    t.string "intermediate_region_code", limit: 3
-    t.index ["alpha2"], name: "index_countries_on_alpha2", unique: true
-    t.index ["alpha3"], name: "index_countries_on_alpha3", unique: true
-    t.index ["name"], name: "index_countries_on_name", unique: true
+  create_table 'countries', force: :cascade do |t|
+    t.string 'name', limit: 100
+    t.string 'alpha2', limit: 2
+    t.string 'alpha3', limit: 3
+    t.string 'country_code', limit: 3
+    t.string 'region', limit: 50
+    t.string 'sub_region', limit: 50
+    t.string 'intermediate_region', limit: 50
+    t.string 'region_code', limit: 3
+    t.string 'sub_region_code', limit: 3
+    t.string 'intermediate_region_code', limit: 3
+    t.index ['alpha2'], name: 'index_countries_on_alpha2', unique: true
+    t.index ['alpha3'], name: 'index_countries_on_alpha3', unique: true
+    t.index ['name'], name: 'index_countries_on_name', unique: true
   end
 
-  create_table "diseases", force: :cascade do |t|
-    t.string "display"
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'diseases', force: :cascade do |t|
+    t.string 'display'
+    t.string 'name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "plan_actions", force: :cascade do |t|
-    t.integer "plan_id"
-    t.integer "benchmark_indicator_action_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "benchmark_indicator_id"
-    t.integer "benchmark_technical_area_id"
-    t.index ["plan_id"], name: "index_plan_actions_on_plan_id"
+  create_table 'plan_actions', force: :cascade do |t|
+    t.integer 'plan_id'
+    t.integer 'benchmark_indicator_action_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'benchmark_indicator_id'
+    t.integer 'benchmark_technical_area_id'
+    t.index ['plan_id'], name: 'index_plan_actions_on_plan_id'
   end
 
-  create_table "plan_diseases", id: false, force: :cascade do |t|
-    t.bigint "plan_id", null: false
-    t.bigint "disease_id", null: false
-    t.index ["plan_id", "disease_id"], name: "index_plan_diseases_on_plan_id_and_disease_id", unique: true
+  create_table 'plan_diseases', id: false, force: :cascade do |t|
+    t.bigint 'plan_id', null: false
+    t.bigint 'disease_id', null: false
+    t.index %w[plan_id disease_id],
+            name: 'index_plan_diseases_on_plan_id_and_disease_id',
+            unique: true
   end
 
-  create_table "plan_goals", force: :cascade do |t|
-    t.integer "plan_id", null: false
-    t.integer "assessment_indicator_id", null: false
-    t.integer "benchmark_indicator_id", null: false
-    t.integer "value", null: false
+  create_table 'plan_goals', force: :cascade do |t|
+    t.integer 'plan_id', null: false
+    t.integer 'assessment_indicator_id', null: false
+    t.integer 'benchmark_indicator_id', null: false
+    t.integer 'value'
   end
 
-  create_table "plans", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.integer "assessment_id"
-    t.integer "term"
-    t.index ["user_id"], name: "index_plans_on_user_id"
+  create_table 'plans', force: :cascade do |t|
+    t.string 'name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'user_id'
+    t.integer 'assessment_id'
+    t.integer 'term'
+    t.index ['user_id'], name: 'index_plans_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "role", null: false
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'role', null: false
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'confirmation_token'
+    t.datetime 'confirmed_at'
+    t.datetime 'confirmation_sent_at'
+    t.string 'unconfirmed_email'
+    t.index ['confirmation_token'],
+            name: 'index_users_on_confirmation_token',
+            unique: true
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'],
+            name: 'index_users_on_reset_password_token',
+            unique: true
   end
 
-  add_foreign_key "assessment_indicators", "assessment_technical_areas"
-  add_foreign_key "assessment_indicators_benchmark_indicators", "assessment_indicators"
-  add_foreign_key "assessment_indicators_benchmark_indicators", "benchmark_indicators"
-  add_foreign_key "assessment_scores", "assessment_indicators"
-  add_foreign_key "assessment_scores", "assessments"
-  add_foreign_key "assessment_technical_areas", "assessment_publications"
-  add_foreign_key "assessments", "assessment_publications"
-  add_foreign_key "assessments", "countries", column: "country_alpha3", primary_key: "alpha3"
-  add_foreign_key "benchmark_indicator_actions", "benchmark_indicators"
-  add_foreign_key "benchmark_indicator_actions", "diseases"
-  add_foreign_key "benchmark_indicators", "benchmark_technical_areas"
-  add_foreign_key "plan_actions", "benchmark_indicator_actions"
-  add_foreign_key "plan_actions", "benchmark_indicators"
-  add_foreign_key "plan_actions", "benchmark_technical_areas"
-  add_foreign_key "plan_actions", "plans"
-  add_foreign_key "plan_diseases", "diseases"
-  add_foreign_key "plan_diseases", "plans"
-  add_foreign_key "plan_goals", "assessment_indicators"
-  add_foreign_key "plan_goals", "benchmark_indicators"
-  add_foreign_key "plan_goals", "plans"
-  add_foreign_key "plans", "assessments"
-  add_foreign_key "plans", "users"
+  add_foreign_key 'assessment_indicators', 'assessment_technical_areas'
+  add_foreign_key 'assessment_indicators_benchmark_indicators',
+                  'assessment_indicators'
+  add_foreign_key 'assessment_indicators_benchmark_indicators',
+                  'benchmark_indicators'
+  add_foreign_key 'assessment_scores', 'assessment_indicators'
+  add_foreign_key 'assessment_scores', 'assessments'
+  add_foreign_key 'assessment_technical_areas', 'assessment_publications'
+  add_foreign_key 'assessments', 'assessment_publications'
+  add_foreign_key 'assessments',
+                  'countries',
+                  column: 'country_alpha3',
+                  primary_key: 'alpha3'
+  add_foreign_key 'benchmark_indicator_actions', 'benchmark_indicators'
+  add_foreign_key 'benchmark_indicator_actions', 'diseases'
+  add_foreign_key 'benchmark_indicators', 'benchmark_technical_areas'
+  add_foreign_key 'plan_actions', 'benchmark_indicator_actions'
+  add_foreign_key 'plan_actions', 'benchmark_indicators'
+  add_foreign_key 'plan_actions', 'benchmark_technical_areas'
+  add_foreign_key 'plan_actions', 'plans'
+  add_foreign_key 'plan_diseases', 'diseases'
+  add_foreign_key 'plan_diseases', 'plans'
+  add_foreign_key 'plan_goals', 'assessment_indicators'
+  add_foreign_key 'plan_goals', 'benchmark_indicators'
+  add_foreign_key 'plan_goals', 'plans'
+  add_foreign_key 'plans', 'assessments'
+  add_foreign_key 'plans', 'users'
 end

--- a/test/javascript/src/components/List/IndicatorActionList.test.js
+++ b/test/javascript/src/components/List/IndicatorActionList.test.js
@@ -37,14 +37,39 @@ describe("when a goal is present", () => {
   const mockIndicatorMap = { 1: {} }
 
   describe("and there are actions present", () => {
-    const mockPlanGoalMap = { 17: { id: 1 } }
+    const mockPlanGoalMap = { 17: { id: 2, value: 3 } }
     const mockPlanActionIdsByIndicator = { 17: [2, 11, 5] }
     const mockAllActions = [
-      { id: 2, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
-      { id: 5, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
-      { id: 13, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
-      { id: 11, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
-      { i2: 6, benchmark_technical_area_id: 1, benchmark_indicator_id: 1 },
+      {
+        id: 2,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: 1,
+      },
+      {
+        id: 5,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+      {
+        id: 13,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+      {
+        id: 11,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: 2,
+      },
+      {
+        id: 6,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
     ]
 
     beforeEach(() => {
@@ -55,7 +80,7 @@ describe("when a goal is present", () => {
       beforeEach(() => {
         const mockPlanDiseases = [
           { id: 1, name: "influenza", display: "Influenza" },
-          { id: 1, name: "cholera", display: "Cholera" },
+          { id: 2, name: "cholera", display: "Cholera" },
         ]
         useSelector
           .mockReturnValueOnce(mockPlanGoalMap)
@@ -135,7 +160,7 @@ describe("when a goal is present", () => {
 
   describe("and there are zero actions", () => {
     beforeEach(() => {
-      let mockPlanGoalMap = { 17: { id: 1 } }
+      let mockPlanGoalMap = { 17: { id: 2, value: null } }
       let mockPlanActionIdsByIndicator = []
       let mockAllActions = []
       const mockPlanDiseases = []
@@ -170,7 +195,7 @@ describe("when a goal is present", () => {
         expect(foundGeneralActionsComponents.length).toEqual(1)
         expect(foundDiseaseActionsComponents.length).toEqual(0)
         expect(foundAddActionComponents.length).toEqual(1)
-        expect(foundNoGoalComponent.length).toEqual(0)
+        expect(foundNoGoalComponent.length).toEqual(1)
       })
     })
   })
@@ -179,11 +204,45 @@ describe("when a goal is present", () => {
 describe("when there is no goal", () => {
   beforeEach(() => {
     const mockTechnicalAreaMap = { 1: {} }
-    const mockIndicatorMap = { 1: {} }
-    const mockPlanGoalMap = { 17: null }
-    const mockPlanActionIdsByIndicator = []
-    const mockAllActions = []
-    const mockPlanDiseases = []
+    const mockIndicatorMap = { 1: { id: 2, value: null } }
+    const mockPlanGoalMap = { 17: { id: 2, value: null } }
+    const mockPlanActionIdsByIndicator = { 17: [2, 11, 5] }
+    const mockPlanDiseases = [
+      { id: 1, name: "influenza", display: "Influenza" },
+      { id: 2, name: "cholera", display: "Cholera" },
+    ]
+    const mockAllActions = [
+      {
+        id: 2,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: 1,
+      },
+      {
+        id: 5,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+      {
+        id: 13,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+      {
+        id: 11,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+      {
+        id: 6,
+        benchmark_technical_area_id: 1,
+        benchmark_indicator_id: 1,
+        disease_id: null,
+      },
+    ]
     useSelector
       .mockReturnValueOnce(mockPlanGoalMap)
       .mockReturnValueOnce(mockPlanActionIdsByIndicator)
@@ -193,7 +252,7 @@ describe("when there is no goal", () => {
       .mockReturnValueOnce(mockPlanDiseases)
   })
 
-  it("renders only a NoGoalForThisIndicator", () => {
+  it("renders NoGoalForThisIndicator, any Actions, and Add Action", () => {
     act(() => {
       ReactDOM.render(<IndicatorActionList indicator={{ id: 17 }} />, container)
     })
@@ -209,10 +268,10 @@ describe("when there is no goal", () => {
     const foundNoGoalComponent = container.querySelectorAll(
       "mock-NoGoalForThisIndicator"
     )
-    expect(foundGeneralActionsComponents.length).toEqual(0)
-    expect(foundDiseaseActionsComponents.length).toEqual(0)
-    expect(foundAddActionComponents.length).toEqual(0)
-    expect(foundAddActionComponents.length).toEqual(0)
+    expect(foundGeneralActionsComponents.length).toEqual(1)
+    expect(foundDiseaseActionsComponents.length).toEqual(2)
+    expect(foundAddActionComponents.length).toEqual(1)
+    expect(foundAddActionComponents.length).toEqual(1)
     expect(foundNoGoalComponent.length).toEqual(1)
   })
 })

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -1,299 +1,300 @@
-require File.expand_path("./test/test_helper")
-require "minitest/spec"
-require "minitest/autorun"
+require File.expand_path('./test/test_helper')
+require 'minitest/spec'
+require 'minitest/autorun'
 
 def assessment_for_nigeria_jee1
-  Assessment.find_by_country_alpha3_and_assessment_publication_id! "NGA", 1
+  Assessment.find_by_country_alpha3_and_assessment_publication_id! 'NGA', 1
 end
 
 def assessment_nigeria_spar2018
-  Assessment.find_by_country_alpha3_and_assessment_publication_id! "NGA", 2
+  Assessment.find_by_country_alpha3_and_assessment_publication_id! 'NGA', 2
 end
 
 describe Plan do
   let(:indicator_attrs_for_nigeria_jee1_1yr) do
     {
-      jee1_ind_p11: "1",
-      jee1_ind_p11_goal: "2",
-      jee1_ind_p12: "1",
-      jee1_ind_p12_goal: "2",
-      jee1_ind_p21: "2",
-      jee1_ind_p21_goal: "3",
-      jee1_ind_p31: "2",
-      jee1_ind_p31_goal: "3",
-      jee1_ind_p32: "2",
-      jee1_ind_p32_goal: "3",
-      jee1_ind_p33: "2",
-      jee1_ind_p33_goal: "3",
-      jee1_ind_p34: "2",
-      jee1_ind_p34_goal: "3",
-      jee1_ind_p41: "2",
-      jee1_ind_p41_goal: "3",
-      jee1_ind_p42: "3",
-      jee1_ind_p42_goal: "4",
-      jee1_ind_p43: "1",
-      jee1_ind_p43_goal: "2",
-      jee1_ind_p51: "2",
-      jee1_ind_p51_goal: "3",
-      jee1_ind_p61: "1",
-      jee1_ind_p61_goal: "2",
-      jee1_ind_p62: "1",
-      jee1_ind_p62_goal: "2",
-      jee1_ind_p71: "3",
-      jee1_ind_p71_goal: "4",
-      jee1_ind_p72: "4",
-      jee1_ind_p72_goal: "5",
-      jee1_ind_d11: "3",
-      jee1_ind_d11_goal: "4",
-      jee1_ind_d12: "1",
-      jee1_ind_d12_goal: "2",
-      jee1_ind_d13: "2",
-      jee1_ind_d13_goal: "3",
-      jee1_ind_d14: "2",
-      jee1_ind_d14_goal: "3",
-      jee1_ind_d21: "3",
-      jee1_ind_d21_goal: "4",
-      jee1_ind_d22: "2",
-      jee1_ind_d22_goal: "3",
-      jee1_ind_d23: "3",
-      jee1_ind_d23_goal: "4",
-      jee1_ind_d24: "3",
-      jee1_ind_d24_goal: "4",
-      jee1_ind_d31: "3",
-      jee1_ind_d31_goal: "4",
-      jee1_ind_d32: "2",
-      jee1_ind_d32_goal: "3",
-      jee1_ind_d41: "3",
-      jee1_ind_d41_goal: "4",
-      jee1_ind_d42: "4",
-      jee1_ind_d42_goal: "5",
-      jee1_ind_d43: "2",
-      jee1_ind_d43_goal: "3",
-      jee1_ind_r11: "1",
-      jee1_ind_r11_goal: "2",
-      jee1_ind_r12: "1",
-      jee1_ind_r12_goal: "2",
-      jee1_ind_r21: "2",
-      jee1_ind_r21_goal: "3",
-      jee1_ind_r22: "2",
-      jee1_ind_r22_goal: "3",
-      jee1_ind_r23: "3",
-      jee1_ind_r23_goal: "4",
-      jee1_ind_r24: "2",
-      jee1_ind_r24_goal: "3",
-      jee1_ind_r31: "1",
-      jee1_ind_r31_goal: "2",
-      jee1_ind_r41: "1",
-      jee1_ind_r41_goal: "2",
-      jee1_ind_r42: "1",
-      jee1_ind_r42_goal: "2",
-      jee1_ind_r51: "1",
-      jee1_ind_r51_goal: "2",
-      jee1_ind_r52: "3",
-      jee1_ind_r52_goal: "4",
-      jee1_ind_r53: "2",
-      jee1_ind_r53_goal: "3",
-      jee1_ind_r54: "3",
-      jee1_ind_r54_goal: "4",
-      jee1_ind_r55: "3",
-      jee1_ind_r55_goal: "4",
-      jee1_ind_poe1: "1",
-      jee1_ind_poe1_goal: "2",
-      jee1_ind_poe2: "1",
-      jee1_ind_poe2_goal: "2",
-      jee1_ind_ce1: "1",
-      jee1_ind_ce1_goal: "2",
-      jee1_ind_ce2: "2",
-      jee1_ind_ce2_goal: "3",
-      jee1_ind_re1: "3",
-      jee1_ind_re1_goal: "4",
-      jee1_ind_re2: "3",
-      jee1_ind_re2_goal: "4",
+      jee1_ind_p11: '1',
+      jee1_ind_p11_goal: '2',
+      jee1_ind_p12: '1',
+      jee1_ind_p12_goal: '2',
+      jee1_ind_p21: '2',
+      jee1_ind_p21_goal: '3',
+      jee1_ind_p31: '2',
+      jee1_ind_p31_goal: '3',
+      jee1_ind_p32: '2',
+      jee1_ind_p32_goal: '3',
+      jee1_ind_p33: '2',
+      jee1_ind_p33_goal: '3',
+      jee1_ind_p34: '2',
+      jee1_ind_p34_goal: '3',
+      jee1_ind_p41: '2',
+      jee1_ind_p41_goal: '3',
+      jee1_ind_p42: '3',
+      jee1_ind_p42_goal: '4',
+      jee1_ind_p43: '1',
+      jee1_ind_p43_goal: '2',
+      jee1_ind_p51: '2',
+      jee1_ind_p51_goal: '3',
+      jee1_ind_p61: '1',
+      jee1_ind_p61_goal: '2',
+      jee1_ind_p62: '1',
+      jee1_ind_p62_goal: '2',
+      jee1_ind_p71: '3',
+      jee1_ind_p71_goal: '4',
+      jee1_ind_p72: '4',
+      jee1_ind_p72_goal: '5',
+      jee1_ind_d11: '3',
+      jee1_ind_d11_goal: '4',
+      jee1_ind_d12: '1',
+      jee1_ind_d12_goal: '2',
+      jee1_ind_d13: '2',
+      jee1_ind_d13_goal: '3',
+      jee1_ind_d14: '2',
+      jee1_ind_d14_goal: '3',
+      jee1_ind_d21: '3',
+      jee1_ind_d21_goal: '4',
+      jee1_ind_d22: '2',
+      jee1_ind_d22_goal: '3',
+      jee1_ind_d23: '3',
+      jee1_ind_d23_goal: '4',
+      jee1_ind_d24: '3',
+      jee1_ind_d24_goal: '4',
+      jee1_ind_d31: '3',
+      jee1_ind_d31_goal: '4',
+      jee1_ind_d32: '2',
+      jee1_ind_d32_goal: '3',
+      jee1_ind_d41: '3',
+      jee1_ind_d41_goal: '4',
+      jee1_ind_d42: '4',
+      jee1_ind_d42_goal: '5',
+      jee1_ind_d43: '2',
+      jee1_ind_d43_goal: '3',
+      jee1_ind_r11: '1',
+      jee1_ind_r11_goal: '2',
+      jee1_ind_r12: '1',
+      jee1_ind_r12_goal: '2',
+      jee1_ind_r21: '2',
+      jee1_ind_r21_goal: '3',
+      jee1_ind_r22: '2',
+      jee1_ind_r22_goal: '3',
+      jee1_ind_r23: '3',
+      jee1_ind_r23_goal: '4',
+      jee1_ind_r24: '2',
+      jee1_ind_r24_goal: '3',
+      jee1_ind_r31: '1',
+      jee1_ind_r31_goal: '2',
+      jee1_ind_r41: '1',
+      jee1_ind_r41_goal: '2',
+      jee1_ind_r42: '1',
+      jee1_ind_r42_goal: '2',
+      jee1_ind_r51: '1',
+      jee1_ind_r51_goal: '2',
+      jee1_ind_r52: '3',
+      jee1_ind_r52_goal: '4',
+      jee1_ind_r53: '2',
+      jee1_ind_r53_goal: '3',
+      jee1_ind_r54: '3',
+      jee1_ind_r54_goal: '4',
+      jee1_ind_r55: '3',
+      jee1_ind_r55_goal: '4',
+      jee1_ind_poe1: '1',
+      jee1_ind_poe1_goal: '2',
+      jee1_ind_poe2: '1',
+      jee1_ind_poe2_goal: '2',
+      jee1_ind_ce1: '1',
+      jee1_ind_ce1_goal: '2',
+      jee1_ind_ce2: '2',
+      jee1_ind_ce2_goal: '3',
+      jee1_ind_re1: '3',
+      jee1_ind_re1_goal: '4',
+      jee1_ind_re2: '3',
+      jee1_ind_re2_goal: '4'
     }.with_indifferent_access
   end
 
-  describe "#validation" do
-    it "requires an assessment" do
+  describe '#validation' do
+    it 'requires an assessment' do
       plan = Plan.new
       _(plan.valid?).must_equal false, plan.errors.inspect
       _(plan.errors[:assessment].present?).must_equal true
     end
 
-    it "requires a name" do
+    it 'requires a name' do
       plan = Plan.new
       _(plan.valid?).must_equal false, plan.errors.inspect
       _(plan.errors[:name].present?).must_equal true
     end
 
-    it "requires a term" do
+    it 'requires a term' do
       plan = Plan.new
       _(plan.valid?).must_equal false, plan.errors.inspect
       _(plan.errors[:term].present?).must_equal true
     end
 
-    it "works when valid" do
+    it 'works when valid' do
       assessment = assessment_for_nigeria_jee1
-      plan = Plan.new name: "blah plan", assessment: assessment, term: 100
+      plan = Plan.new name: 'blah plan', assessment: assessment, term: 100
       _(plan.valid?).must_equal true, plan.errors.inspect
     end
   end
 
-  describe "#is_5_year?" do
+  describe '#is_5_year?' do
     let(:subject) { Plan.new }
 
-    it "is false by default" do
+    it 'is false by default' do
       _(subject.is_5_year?).must_equal false
     end
 
-    it "is true when set to 5 year" do
+    it 'is true when set to 5 year' do
       subject.term = Plan::TERM_TYPES.second
 
       _(subject.is_5_year?).must_equal true
     end
   end
 
-  describe ".new_from_assessment" do
-    describe "for Nigeria JEE 5-year plan" do
+  describe '.new_from_assessment' do
+    describe 'for Nigeria JEE 5-year plan' do
       let(:subject) do
         Plan.new_from_assessment(
-          assessment: assessment_for_nigeria_jee1, is_5_year_plan: true,
+          assessment: assessment_for_nigeria_jee1,
+          is_5_year_plan: true
         )
       end
 
-      it "has the expected assessment" do
+      it 'has the expected assessment' do
         _(subject.assessment).must_equal assessment_for_nigeria_jee1
       end
 
-      it "has the expected name" do
-        _(subject.name).must_equal "Nigeria draft plan"
+      it 'has the expected name' do
+        _(subject.name).must_equal 'Nigeria draft plan'
       end
 
-      it "has the expected term" do
+      it 'has the expected term' do
         _(subject.term).must_equal 500
       end
     end
   end
 
-  describe ".create_from_goal_form" do
-    describe "for Nigeria JEE1" do
+  describe '.create_from_goal_form' do
+    describe 'for Nigeria JEE1' do
       let(:plan) do
         Plan.create_from_goal_form(
           indicator_attrs: indicator_attrs_for_nigeria_jee1_1yr,
           assessment: assessment_for_nigeria_jee1,
-          plan_name: "test plan 3854",
+          plan_name: 'test plan 3854'
         )
       end
 
-      it "returns a saved plan instance" do
-        _(plan.persisted?).must_equal(true, "Plan was not saved")
+      it 'returns a saved plan instance' do
+        _(plan.persisted?).must_equal(true, 'Plan was not saved')
       end
 
-      it "has the expected term" do
+      it 'has the expected term' do
         _(plan.term).must_equal(Plan::TERM_TYPES.first)
       end
 
-      it "has the expected name" do
-        _(plan.name).must_equal("test plan 3854")
+      it 'has the expected name' do
+        _(plan.name).must_equal('test plan 3854')
       end
 
-      it "has the expected number of indicators" do
-        _(plan.goals.size).must_equal(39)
+      it 'has the expected number of indicators' do
+        _(plan.goals.size).must_equal(44)
       end
 
-      it "has the expected number of actions" do
-        _(plan.plan_actions.size).must_equal(235)
+      it 'has the expected number of actions' do
+        _(plan.plan_actions.size).must_equal(337)
       end
     end
 
-    describe "for Nigeria SPAR 2018" do
+    describe 'for Nigeria SPAR 2018' do
       let(:indicator_attrs) do
         {
-          spar_2018_ind_c11: "4",
-          spar_2018_ind_c11_goal: "5",
-          spar_2018_ind_c12: "2",
-          spar_2018_ind_c12_goal: "3",
-          spar_2018_ind_c13: "3",
-          spar_2018_ind_c13_goal: "4",
-          spar_2018_ind_c21: "5",
-          spar_2018_ind_c21_goal: "5",
-          spar_2018_ind_c22: "5",
-          spar_2018_ind_c22_goal: "5",
-          spar_2018_ind_c31: "3",
-          spar_2018_ind_c31_goal: "4",
-          spar_2018_ind_c41: "4",
-          spar_2018_ind_c41_goal: "5",
-          spar_2018_ind_c51: "2",
-          spar_2018_ind_c51_goal: "3",
-          spar_2018_ind_c52: "1",
-          spar_2018_ind_c52_goal: "2",
-          spar_2018_ind_c53: "1",
-          spar_2018_ind_c53_goal: "2",
-          spar_2018_ind_c61: "4",
-          spar_2018_ind_c61_goal: "5",
-          spar_2018_ind_c62: "4",
-          spar_2018_ind_c62_goal: "5",
-          spar_2018_ind_c71: "3",
-          spar_2018_ind_c71_goal: "4",
-          spar_2018_ind_c81: "2",
-          spar_2018_ind_c81_goal: "3",
-          spar_2018_ind_c82: "3",
-          spar_2018_ind_c82_goal: "4",
-          spar_2018_ind_c83: "1",
-          spar_2018_ind_c83_goal: "2",
-          spar_2018_ind_c91: "2",
-          spar_2018_ind_c91_goal: "3",
-          spar_2018_ind_c92: "2",
-          spar_2018_ind_c92_goal: "3",
-          spar_2018_ind_c93: "1",
-          spar_2018_ind_c93_goal: "2",
-          spar_2018_ind_c101: "2",
-          spar_2018_ind_c101_goal: "3",
-          spar_2018_ind_c111: "2",
-          spar_2018_ind_c111_goal: "3",
-          spar_2018_ind_c112: "2",
-          spar_2018_ind_c112_goal: "3",
-          spar_2018_ind_c121: "1",
-          spar_2018_ind_c121_goal: "2",
-          spar_2018_ind_c131: "2",
-          spar_2018_ind_c131_goal: "3",
+          spar_2018_ind_c11: '4',
+          spar_2018_ind_c11_goal: '5',
+          spar_2018_ind_c12: '2',
+          spar_2018_ind_c12_goal: '3',
+          spar_2018_ind_c13: '3',
+          spar_2018_ind_c13_goal: '4',
+          spar_2018_ind_c21: '5',
+          spar_2018_ind_c21_goal: '5',
+          spar_2018_ind_c22: '5',
+          spar_2018_ind_c22_goal: '5',
+          spar_2018_ind_c31: '3',
+          spar_2018_ind_c31_goal: '4',
+          spar_2018_ind_c41: '4',
+          spar_2018_ind_c41_goal: '5',
+          spar_2018_ind_c51: '2',
+          spar_2018_ind_c51_goal: '3',
+          spar_2018_ind_c52: '1',
+          spar_2018_ind_c52_goal: '2',
+          spar_2018_ind_c53: '1',
+          spar_2018_ind_c53_goal: '2',
+          spar_2018_ind_c61: '4',
+          spar_2018_ind_c61_goal: '5',
+          spar_2018_ind_c62: '4',
+          spar_2018_ind_c62_goal: '5',
+          spar_2018_ind_c71: '3',
+          spar_2018_ind_c71_goal: '4',
+          spar_2018_ind_c81: '2',
+          spar_2018_ind_c81_goal: '3',
+          spar_2018_ind_c82: '3',
+          spar_2018_ind_c82_goal: '4',
+          spar_2018_ind_c83: '1',
+          spar_2018_ind_c83_goal: '2',
+          spar_2018_ind_c91: '2',
+          spar_2018_ind_c91_goal: '3',
+          spar_2018_ind_c92: '2',
+          spar_2018_ind_c92_goal: '3',
+          spar_2018_ind_c93: '1',
+          spar_2018_ind_c93_goal: '2',
+          spar_2018_ind_c101: '2',
+          spar_2018_ind_c101_goal: '3',
+          spar_2018_ind_c111: '2',
+          spar_2018_ind_c111_goal: '3',
+          spar_2018_ind_c112: '2',
+          spar_2018_ind_c112_goal: '3',
+          spar_2018_ind_c121: '1',
+          spar_2018_ind_c121_goal: '2',
+          spar_2018_ind_c131: '2',
+          spar_2018_ind_c131_goal: '3'
         }.with_indifferent_access
       end
       let(:plan) do
         Plan.create_from_goal_form(
           indicator_attrs: indicator_attrs,
           assessment: assessment_nigeria_spar2018,
-          plan_name: "test plan 9391",
+          plan_name: 'test plan 9391'
         )
       end
 
-      it "returns a saved plan instance" do
-        assert plan.persisted?, "Plan was not saved"
+      it 'returns a saved plan instance' do
+        assert plan.persisted?, 'Plan was not saved'
       end
 
-      it "has the expected name" do
-        assert plan.name, "test plan 9391"
+      it 'has the expected name' do
+        assert plan.name, 'test plan 9391'
       end
 
-      it "has the expected number of indicators" do
-        assert_equal 36, plan.goals.size
+      it 'has the expected number of indicators' do
+        assert_equal 44, plan.goals.size
       end
 
-      it "has the expected number of actions" do
-        assert_equal 182, plan.plan_actions.size
+      it 'has the expected number of actions' do
+        assert_equal 284, plan.plan_actions.size
       end
     end
 
-    describe "for Nigeria from technical areas 5-year" do
+    describe 'for Nigeria from technical areas 5-year' do
       let(:indicator_attrs) do
         {
-          spar_2018_ind_c21: "1",
-          spar_2018_ind_c21_goal: "2",
-          spar_2018_ind_c22: "1",
-          spar_2018_ind_c22_goal: "2",
-          spar_2018_ind_c61: "1",
-          spar_2018_ind_c61_goal: "2",
-          spar_2018_ind_c62: "1",
-          spar_2018_ind_c62_goal: "2",
+          spar_2018_ind_c21: '1',
+          spar_2018_ind_c21_goal: '2',
+          spar_2018_ind_c22: '1',
+          spar_2018_ind_c22_goal: '2',
+          spar_2018_ind_c61: '1',
+          spar_2018_ind_c61_goal: '2',
+          spar_2018_ind_c62: '1',
+          spar_2018_ind_c62_goal: '2'
         }.with_indifferent_access
       end
       let(:plan) do
@@ -301,153 +302,154 @@ describe Plan do
           indicator_attrs: indicator_attrs,
           assessment: assessment_nigeria_spar2018,
           is_5_year_plan: true,
-          plan_name: "test plan 3737",
+          plan_name: 'test plan 3737'
         )
       end
 
-      it "returns a saved plan instance" do
-        assert plan.persisted?, "Plan was not saved"
+      it 'returns a saved plan instance' do
+        assert plan.persisted?, 'Plan was not saved'
       end
 
-      it "has the expected term" do
+      it 'has the expected term' do
         _(plan.term).must_equal Plan::TERM_TYPES.second
       end
 
-      it "has the expected name" do
-        assert plan.name, "test plan 37373"
+      it 'has the expected name' do
+        assert plan.name, 'test plan 37373'
       end
 
-      it "has the expected number of indicators" do
-        assert_equal 4, plan.goals.size
+      it 'has the expected number of indicators' do
+        assert_equal 44, plan.goals.size
       end
 
-      it "has the expected number of actions" do
-        assert_equal 33, plan.plan_actions.size
+      it 'has the expected number of actions' do
+        assert_equal 135, plan.plan_actions.size
       end
     end
 
-    describe "for Nigeria JEE1 with influenza" do
+    describe 'for Nigeria JEE1 with influenza' do
       let(:plan) do
         Plan.create_from_goal_form(
           indicator_attrs: indicator_attrs_for_nigeria_jee1_1yr,
           assessment: assessment_for_nigeria_jee1,
-          plan_name: "test plan 3854",
-          disease_ids: [Disease.influenza.id],
+          plan_name: 'test plan 3854',
+          disease_ids: [Disease.influenza.id]
         )
       end
 
-      it "returns a saved plan instance" do
-        assert plan.persisted?, "Plan was not saved"
+      it 'returns a saved plan instance' do
+        assert plan.persisted?, 'Plan was not saved'
       end
 
-      it "has the expected term" do
+      it 'has the expected term' do
         _(plan.term).must_equal Plan::TERM_TYPES.first
       end
 
-      it "has the expected name" do
-        assert_equal "test plan 3854", plan.name
+      it 'has the expected name' do
+        assert_equal 'test plan 3854', plan.name
       end
 
-      it "has the expected number of indicators" do
-        assert_equal 39, plan.goals.size
+      it 'has the expected number of indicators' do
+        assert_equal 44, plan.goals.size
       end
 
-      it "has the expected number of actions" do
-        assert_equal (283), plan.plan_actions.size
+      it 'has the expected number of actions' do
+        assert_equal (337), plan.plan_actions.size
       end
 
-      it "influenza actions have been assigned to the appropriate indicator" do
-        indicator = BenchmarkIndicator.first
-        actions_for_indicator_count =
-          BenchmarkIndicatorAction.where(
-            benchmark_indicator_id: indicator.id, disease_id: Disease.influenza,
-          ).count
-        assert_equal 2, actions_for_indicator_count
-      end
-
-      it "has associated diseases influenza" do
-        assert_equal plan.diseases, [Disease.influenza]
-      end
-    end
-
-    describe "for Nigeria JEE1 with influenza and cholera" do
-      let(:plan) do
-        Plan.create_from_goal_form(
-          indicator_attrs: indicator_attrs_for_nigeria_jee1_1yr,
-          assessment: assessment_for_nigeria_jee1,
-          plan_name: "test plan 3854",
-          disease_ids: [Disease.influenza.id, Disease.cholera.id],
-        )
-      end
-
-      it "returns a saved plan instance" do
-        assert plan.persisted?, "Plan was not saved"
-      end
-
-      it "has the expected term" do
-        _(plan.term).must_equal Plan::TERM_TYPES.first
-      end
-
-      it "has the expected name" do
-        assert_equal "test plan 3854", plan.name
-      end
-
-      it "has the expected number of indicators" do
-        assert_equal 39, plan.goals.size
-      end
-
-      it "has the expected number of actions" do
-        assert_equal (327), plan.plan_actions.size
-      end
-
-      it "influenza actions and cholera actions have been assigned to the appropriate indicator" do
+      it 'influenza actions have been assigned to the appropriate indicator' do
         indicator = BenchmarkIndicator.first
         actions_for_indicator_count =
           BenchmarkIndicatorAction.where(
             benchmark_indicator_id: indicator.id,
-            disease_id: [Disease.influenza, Disease.cholera],
+            disease_id: Disease.influenza
+          ).count
+        assert_equal 2, actions_for_indicator_count
+      end
+
+      it 'has associated diseases influenza' do
+        assert_equal plan.diseases, [Disease.influenza]
+      end
+    end
+
+    describe 'for Nigeria JEE1 with influenza and cholera' do
+      let(:plan) do
+        Plan.create_from_goal_form(
+          indicator_attrs: indicator_attrs_for_nigeria_jee1_1yr,
+          assessment: assessment_for_nigeria_jee1,
+          plan_name: 'test plan 3854',
+          disease_ids: [Disease.influenza.id, Disease.cholera.id]
+        )
+      end
+
+      it 'returns a saved plan instance' do
+        assert plan.persisted?, 'Plan was not saved'
+      end
+
+      it 'has the expected term' do
+        _(plan.term).must_equal Plan::TERM_TYPES.first
+      end
+
+      it 'has the expected name' do
+        assert_equal 'test plan 3854', plan.name
+      end
+
+      it 'has the expected number of indicators' do
+        assert_equal 44, plan.goals.size
+      end
+
+      it 'has the expected number of actions' do
+        assert_equal (337), plan.plan_actions.size
+      end
+
+      it 'influenza actions and cholera actions have been assigned to the appropriate indicator' do
+        indicator = BenchmarkIndicator.first
+        actions_for_indicator_count =
+          BenchmarkIndicatorAction.where(
+            benchmark_indicator_id: indicator.id,
+            disease_id: [Disease.influenza, Disease.cholera]
           ).count
         assert_equal 3, actions_for_indicator_count
       end
 
-      it "has associated diseases influenza and cholera" do
+      it 'has associated diseases influenza and cholera' do
         assert_equal plan.diseases, [Disease.influenza, Disease.cholera]
       end
     end
 
-    describe "for Nigeria JEE1 with an invalid disease" do
+    describe 'for Nigeria JEE1 with an invalid disease' do
       let(:indicator_attrs) do
-        { jee1_ind_p11: "1", jee1_ind_p11_goal: "2" }.with_indifferent_access
+        { jee1_ind_p11: '1', jee1_ind_p11_goal: '2' }.with_indifferent_access
       end
 
-      it "raises an exception" do
+      it 'raises an exception' do
         assert_raise Exceptions::InvalidDiseasesError do
           Plan.create_from_goal_form(
             indicator_attrs: indicator_attrs,
             assessment: assessment_for_nigeria_jee1,
-            plan_name: "test plan 3854",
-            disease_ids: [0], # disease id 0 does not exist
+            plan_name: 'test plan 3854',
+            disease_ids: [0] # disease id 0 does not exist
           )
         end
       end
     end
   end
 
-  describe "#count_actions_by_type" do
+  describe '#count_actions_by_type' do
     let(:plan) { create(:plan_nigeria_jee1) }
 
-    it "returns an array of the expected integers" do
+    it 'returns an array of the expected integers' do
       expected = [8, 40, 23, 7, 9, 9, 20, 45, 2, 45, 13, 32, 8, 3, 23]
       _(plan.count_actions_by_type).must_equal expected
     end
   end
 
-  describe "#count_actions_by_ta" do
-    describe "for a full plan" do
+  describe '#count_actions_by_ta' do
+    describe 'for a full plan' do
       let(:benchmark_technical_areas) { BenchmarkTechnicalArea.all }
       let(:plan) { create(:plan_nigeria_jee1) }
 
-      it "returns an array of the expected integers" do
+      it 'returns an array of the expected integers' do
         expected = [
           6,
           12,
@@ -466,7 +468,7 @@ describe Plan do
           20,
           16,
           14,
-          4,
+          4
         ]
 
         result = plan.count_actions_by_ta(benchmark_technical_areas)
@@ -475,20 +477,20 @@ describe Plan do
       end
     end
 
-    describe "for a plan of sparsely populated technical areas" do
+    describe 'for a plan of sparsely populated technical areas' do
       let(:benchmark_technical_areas) { BenchmarkTechnicalArea.all }
       let(:indicator_attrs) do
         {
-          jee1_ind_p21: "2",
-          jee1_ind_p21_goal: "3",
-          jee1_ind_d21: "3",
-          jee1_ind_d21_goal: "4",
-          jee1_ind_d22: "2",
-          jee1_ind_d22_goal: "3",
-          jee1_ind_d23: "3",
-          jee1_ind_d23_goal: "4",
-          jee1_ind_d24: "3",
-          jee1_ind_d24_goal: "4",
+          jee1_ind_p21: '2',
+          jee1_ind_p21_goal: '3',
+          jee1_ind_d21: '3',
+          jee1_ind_d21_goal: '4',
+          jee1_ind_d22: '2',
+          jee1_ind_d22_goal: '3',
+          jee1_ind_d23: '3',
+          jee1_ind_d23_goal: '4',
+          jee1_ind_d24: '3',
+          jee1_ind_d24_goal: '4'
         }.with_indifferent_access
       end
       let(:plan) do
@@ -496,12 +498,12 @@ describe Plan do
           indicator_attrs: indicator_attrs,
           assessment: assessment_for_nigeria_jee1,
           is_5_year_plan: true,
-          plan_name: "test plan 3737",
+          plan_name: 'test plan 3737'
         )
       end
 
-      it "returns an array of the expected integers" do
-        expected = [0, 5, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+      it 'returns an array of the expected integers' do
+        expected = [7, 12, 4, 1, 1, 9, 10, 1, 24, 8, 11, 5, 0, 12, 15, 2, 0, 0]
 
         result = plan.count_actions_by_ta(benchmark_technical_areas)
 
@@ -510,13 +512,13 @@ describe Plan do
     end
   end
 
-  describe "#actions_for" do
+  describe '#actions_for' do
     let(:plan) { create(:plan_nigeria_jee1) }
 
-    it "returns an array of the expected benchmark actions" do
+    it 'returns an array of the expected benchmark actions' do
       expected_pg =
         plan.goals.detect do |pg|
-          pg.benchmark_indicator.display_abbreviation.eql?("2.1")
+          pg.benchmark_indicator.display_abbreviation.eql?('2.1')
         end
       _(expected_pg).wont_be_nil
 
@@ -528,15 +530,16 @@ describe Plan do
     end
   end
 
-  describe "#update" do
+  describe '#update' do
     let(:subject) { create(:plan_nigeria_jee1) }
 
-    it "works as expected" do
+    it 'works as expected' do
       _(subject.persisted?).must_equal true
       _(subject.plan_actions.size).must_equal 235
+
       # this is keeping the pre-exisitng actions and adding one action of id=15
       result =
-        subject.update! name: "changed plan 789",
+        subject.update! name: 'changed plan 789',
                         benchmark_action_ids: [
                           563,
                           370,
@@ -773,7 +776,7 @@ describe Plan do
                           561,
                           562,
                           300,
-                          15,
+                          15
                         ]
 
       _(result).must_equal true

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -31,7 +31,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal 'Nigeria draft plan', find('#plan_name').value
     assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '235', find('.action-count-component .count').text
+    assert_equal '337', find('.action-count-component .count').text
     assert_selector('#technical-area-1') # the first one
     assert_selector('#technical-area-3') # the last one
     assert_selector('.nudge-container') do
@@ -118,7 +118,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal 'Nigeria draft plan', find('#plan_name').value
     assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '327', find('.action-count-component .count').text
+    assert_equal '337', find('.action-count-component .count').text
     assert_selector('#technical-area-1') # the first one
     assert_selector('#technical-area-3') # the last one
     assert_selector('.nudge-container') do
@@ -127,6 +127,31 @@ class AppsTest < ApplicationSystemTestCase
                'Focus on no more than 2-3 actions per technical area'
              )
     end
+
+    ##
+    # Make sure there are the correct number of indicators with no capacity gap
+    indicators_no_capacity_gap = all('.benchmark-container .no-capacity-gap')
+    indicator_headings =
+      indicators_no_capacity_gap.map do |indicator|
+        indicator.ancestor('.benchmark-container').find('.header').text
+      end
+    assert_equal(
+      indicator_headings,
+      [
+        'Benchmark 1.2: Financing is available for the implementation of IHR capacities',
+        'Benchmark 1.3: Financing available for timely response to public health emergencies',
+        'Benchmark 3.1: Effective multisectoral coordination on AMR',
+        'Benchmark 10.3: In-service trainings are available',
+        'Benchmark 12.1: Functional emergency response coordination is in place'
+      ]
+    )
+
+    # and make sure there are Add Action components for each of these indicators
+    add_actions =
+      indicators_no_capacity_gap.map do |indicator|
+        indicator.ancestor('.benchmark-container').find('.action-form')
+      end
+    assert(add_actions.count == indicators_no_capacity_gap.count)
 
     ##
     # make sure Technical Area tab has a legend
@@ -241,10 +266,9 @@ class AppsTest < ApplicationSystemTestCase
            )
     click_on('email@example.com')
     click_on('My Plans')
-    sleep 0.2
-
     assert page.has_content?('Saved Nigeria Plan 789')
     click_on('Saved Nigeria Plan 789')
+    sleep 0.2
     assert page.has_content?('National Legislation, Policy and Financing')
     click_on('email@example.com')
     click_on('My Plans')
@@ -286,7 +310,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_equal 'Actions', find('.action-count-component .label').text
 
     # action count was 103 but became 98 along with refactoring changes, I think due to bug(s) fixed
-    assert_equal '107', find('.action-count-component .count').text
+    assert_equal '209', find('.action-count-component .count').text
     assert page.has_content?(
              'Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors.'
            )
@@ -351,7 +375,7 @@ class AppsTest < ApplicationSystemTestCase
     assert_current_path(%r{^\/plans\/\d+$})
     assert_equal 'Nigeria draft plan', find('#plan_name').value
     assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '28', find('.action-count-component .count').text
+    assert_equal '130', find('.action-count-component .count').text
     assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 


### PR DESCRIPTION
- remove null constraint from plan_goals value
- extract methods from create_from_goal_form to make it more readable
- update goal value if benchmark indicator already seen and there is a goal value
- update IndicatorActionList to detect when there is no capacity gap based on the plan goal value, and to always show actions and AddAction component
- update system tests to check for the correct indicators with no capacity gap also have Add Action components

As an example, the following JEE1 Nigeria 5-year plan with Influenza and Cholera selected used to just show the "There is no capacity gap" message with no actions and no + Add Action component, on these two indicators 1.2 and 1.3, and now they do.

# Screenshots
![Screen Shot 2021-03-16 at 4 02 50 PM](https://user-images.githubusercontent.com/9426/111391103-27ace200-8671-11eb-99b2-b0a30b2ffe93.png)


