### PR TITLE
Add multi-select drop down for action type and technical area filters on respective tabs 

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -462,3 +462,30 @@
     padding: 0.65em 0.65em !important;
   }
 }
+
+.dropdown-filter {
+  .btn-primary:not(:disabled):not(.disabled):active,
+  .btn-primary:not(:disabled):not(.disabled).active,
+  .show > .btn-primary.dropdown-toggle {
+    color: black;
+  }
+  .dropdown-toggle {
+    &.btn-primary {
+      background-color: white;
+      position: relative;
+    }
+    // embedded svg is from images/down-caret.svg with a color change
+    background-image: url('data:image/svg+xml;utf8,<svg width="14" height="9" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.45593 8.27079L0.225371 2.04019C-0.0751237 1.7397 -0.0751237 1.25252 0.225371 0.952059L0.952066 0.225364C1.25205 -0.0746182 1.73823 -0.0751955 2.03892 0.224081L7.00002 5.16194L11.9611 0.224081C12.2618 -0.0751955 12.748 -0.0746182 13.0479 0.225364L13.7746 0.952059C14.0751 1.25255 14.0751 1.73973 13.7746 2.04019L7.5441 8.27079C7.24361 8.57125 6.75643 8.57125 6.45593 8.27079Z" fill="rgba(45,45,43,0.25)" /></svg>');
+    background-repeat: no-repeat;
+    background-position: 98% 50%;
+    background-size: 14px 9px;
+
+    height: 2.2rem;
+    width: 100%;
+    text-align: left;
+    border-radius: 0;
+    border-color: rgba(0, 0, 0, 0.125);
+    color: black;
+    text-transform: none;
+  }
+}

--- a/app/javascript/src/components/ChartCard/ClearFilters.js
+++ b/app/javascript/src/components/ChartCard/ClearFilters.js
@@ -14,7 +14,7 @@ const ClearFilters = () => {
           dispatch(clearFilterCriteria())
         }}
       >
-        Clear Filters
+        Reset Filters
       </a>
     </div>
   )

--- a/app/javascript/src/components/ChartCard/FilterActionType.js
+++ b/app/javascript/src/components/ChartCard/FilterActionType.js
@@ -1,0 +1,57 @@
+import React from "react"
+import { useDispatch, useSelector } from "react-redux"
+import {
+  getPlanChartLabels,
+  getSelectedActionTypeOrdinal,
+  getSelectedChartTabIndex,
+} from "../../config/selectors"
+import Dropdown from "react-bootstrap/Dropdown"
+import { deselectActionType, selectActionType } from "../../config/actions"
+import { makeDropdownItem } from "../../config/helpers"
+
+const FilterActionType = () => {
+  const selectedChartTabIndex = useSelector((state) =>
+    getSelectedChartTabIndex(state)
+  )
+  const selectedActionTypeOrdinal = useSelector((state) =>
+    getSelectedActionTypeOrdinal(state)
+  )
+  const barChartLabels = useSelector((state) => getPlanChartLabels(state))[
+    selectedChartTabIndex
+  ]
+
+  const dispatch = useDispatch()
+
+  const onSelectActionType = (eventKey) => {
+    if (eventKey === "ALL") {
+      dispatch(deselectActionType())
+    } else {
+      dispatch(selectActionType(parseInt(eventKey, 10) - 1))
+    }
+  }
+
+  const allItem = makeDropdownItem("All", "ALL")
+  const items = barChartLabels.map((label, i) => makeDropdownItem(label, i + 1))
+  const selectedText = selectedActionTypeOrdinal
+    ? barChartLabels[selectedActionTypeOrdinal - 1]
+    : "All"
+
+  return (
+    <div className="row dropdown-filter">
+      <div className="col">
+        <Dropdown
+          onSelect={onSelectActionType}
+          id="dropdown-filter-action-type"
+        >
+          <Dropdown.Toggle>{selectedText}</Dropdown.Toggle>
+          <Dropdown.Menu>
+            {allItem}
+            {items}
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    </div>
+  )
+}
+
+export default FilterActionType

--- a/app/javascript/src/components/ChartCard/FilterTechnicalArea.js
+++ b/app/javascript/src/components/ChartCard/FilterTechnicalArea.js
@@ -1,0 +1,59 @@
+import React from "react"
+import { useDispatch, useSelector } from "react-redux"
+import {
+  getPlanChartLabels,
+  getSelectedChartTabIndex,
+  getSelectedTechnicalAreaId,
+} from "../../config/selectors"
+import Dropdown from "react-bootstrap/Dropdown"
+import {
+  deselectTechnicalArea,
+  selectTechnicalArea,
+} from "../../config/actions"
+import { makeDropdownItem } from "../../config/helpers"
+
+const FilterTechnicalArea = () => {
+  const selectedChartTabIndex = useSelector((state) =>
+    getSelectedChartTabIndex(state)
+  )
+  const selectedTechnicalAreaId = useSelector((state) =>
+    getSelectedTechnicalAreaId(state)
+  )
+  const barChartLabels = useSelector((state) => getPlanChartLabels(state))[
+    selectedChartTabIndex
+  ]
+  const dispatch = useDispatch()
+
+  const onSelectTechnicalArea = (eventKey) => {
+    if (eventKey === "ALL") {
+      dispatch(deselectTechnicalArea())
+    } else {
+      dispatch(selectTechnicalArea(parseInt(eventKey, 10)))
+    }
+  }
+
+  const allItem = makeDropdownItem("All", "ALL")
+  const items = barChartLabels.map((label, i) => makeDropdownItem(label, i + 1))
+  const selectedText = selectedTechnicalAreaId
+    ? barChartLabels[selectedTechnicalAreaId - 1]
+    : "All"
+
+  return (
+    <div className="row dropdown-filter">
+      <div className="col">
+        <Dropdown
+          onSelect={onSelectTechnicalArea}
+          id="dropdown-filter-technical-area"
+        >
+          <Dropdown.Toggle>{selectedText}</Dropdown.Toggle>
+          <Dropdown.Menu>
+            {allItem}
+            {items}
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    </div>
+  )
+}
+
+export default FilterTechnicalArea

--- a/app/javascript/src/components/ChartCard/Filters.js
+++ b/app/javascript/src/components/ChartCard/Filters.js
@@ -1,0 +1,38 @@
+import React from "react"
+import ClearFilters from "./ClearFilters"
+import FilterTechnicalArea from "./FilterTechnicalArea"
+import { getSelectedChartTabIndex } from "../../config/selectors"
+import { useSelector } from "react-redux"
+import ActionTypeFilter from "./FilterActionType"
+
+const Filters = () => {
+  const selectedChartTabIndex = useSelector((state) =>
+    getSelectedChartTabIndex(state)
+  )
+  let title, filterComponent
+  if (selectedChartTabIndex === 0) {
+    title = "Technical area filter"
+    filterComponent = <FilterTechnicalArea />
+  } else {
+    title = "Action type filter"
+    filterComponent = <ActionTypeFilter />
+  }
+
+  return (
+    <>
+      <div className="row d-flex justify-content-between mb-1">
+        <div className="col">
+          <strong>{title}</strong>
+        </div>
+        <div className="col text-right">
+          <ClearFilters />
+        </div>
+      </div>
+      <div className="row">
+        <div className="col">{filterComponent}</div>
+      </div>
+    </>
+  )
+}
+
+export default Filters

--- a/app/javascript/src/components/ChartCard/InfoPane.js
+++ b/app/javascript/src/components/ChartCard/InfoPane.js
@@ -1,8 +1,8 @@
 import React from "react"
 import ActionCount from "./ActionCount"
-import ClearFilters from "./ClearFilters"
 import DiseaseToggles from "./DiseaseToggles"
 import BarChartLegend from "./BarChartLegend"
+import Filters from "./Filters"
 
 // this is the best we have found so far:
 //   col-12 col-xl-auto
@@ -12,12 +12,10 @@ import BarChartLegend from "./BarChartLegend"
 const InfoPane = () => {
   return (
     <div className="info-pane-component col-12 col-xl-4">
-      <div className="row d-flex justify-content-between">
-        <ActionCount />
-        <ClearFilters />
-      </div>
+      <Filters />
       <DiseaseToggles />
       <BarChartLegend />
+      <ActionCount />
     </div>
   )
 }

--- a/app/javascript/src/config/actions.js
+++ b/app/javascript/src/config/actions.js
@@ -13,6 +13,8 @@ import {
   UPDATE_PLAN_NAME,
   CLEAR_FILTERS,
   SET_SELECTED_CHART_TAB_INDEX,
+  DESELECT_ACTION_TYPE,
+  DESELECT_TECHNICAL_AREA,
 } from "./constants"
 
 const deleteAnAction = (actionId, indicatorId) => {
@@ -62,6 +64,14 @@ const selectTechnicalArea = (technicalAreaId) => {
   }
 }
 
+const deselectTechnicalArea = () => {
+  return (dispatch) => {
+    dispatch({
+      type: DESELECT_TECHNICAL_AREA,
+    })
+  }
+}
+
 const selectActionType = (actionTypeIndex) => {
   return (dispatch) => {
     dispatch({
@@ -71,6 +81,14 @@ const selectActionType = (actionTypeIndex) => {
     dispatch({
       type: SWITCH_LIST_MODE,
       payload: { listModeOrdinal: LIST_MODE_BY_ACTION_TYPE },
+    })
+  }
+}
+
+const deselectActionType = () => {
+  return (dispatch) => {
+    dispatch({
+      type: DESELECT_ACTION_TYPE,
     })
   }
 }
@@ -108,6 +126,8 @@ const setSelectedChartTabIndex = (tabIndex) => {
 export {
   addActionToIndicator,
   deleteAnAction,
+  deselectActionType,
+  deselectTechnicalArea,
   selectTechnicalArea,
   selectActionType,
   clearFilterCriteria,

--- a/app/javascript/src/config/helpers.js
+++ b/app/javascript/src/config/helpers.js
@@ -1,6 +1,14 @@
 import { getDisease } from "./selectors"
+import Dropdown from "react-bootstrap/Dropdown"
+import React from "react"
 
 const getColorForDiseaseId = (diseases, diseaseId) =>
   `color-value-disease-${getDisease(diseases, diseaseId).name}`
 
-export { getColorForDiseaseId }
+const makeDropdownItem = (label, index) => (
+  <Dropdown.Item eventKey={index} key={`label-${index}`}>
+    {label}
+  </Dropdown.Item>
+)
+
+export { getColorForDiseaseId, makeDropdownItem }

--- a/app/javascript/src/config/reducers.js
+++ b/app/javascript/src/config/reducers.js
@@ -136,16 +136,16 @@ export default function initReducers(initialState) {
       },
       [DESELECT_ACTION_TYPE]: (state /*, dispatchedAction*/) => {
         state.selectedActionTypeOrdinal = null
+        state.selectedListMode = null
         return state
       },
-      [CLEAR_FILTERS]: (/*state, dispatchedAction*/) => {
-        return {
-          selectedListMode: null,
-          selectedTechnicalAreaId: null,
-          selectedActionTypeOrdinal: null,
-          isInfluenzaShowing: true,
-          isCholeraShowing: true,
-        }
+      [CLEAR_FILTERS]: (state) => {
+        state.selectedListMode = null
+        state.selectedTechnicalAreaId = null
+        state.selectedActionTypeOrdinal = null
+        state.isInfluenzaShowing = true
+        state.isCholeraShowing = true
+        return state
       },
       [IS_INFLUENZA_SHOWING]: (state /*, dispatchedAction*/) => {
         state.isInfluenzaShowing = !state.isInfluenzaShowing

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "popper.js": "^1.16.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
+    "react-bootstrap": "^1.5.2",
     "react-chartist": "^0.14.4",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",

--- a/test/javascript/src/components/ChartCard/Filters.test.js
+++ b/test/javascript/src/components/ChartCard/Filters.test.js
@@ -1,0 +1,79 @@
+import { describe } from "@jest/globals"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import ReactDOM from "react-dom"
+import Filters from "components/ChartCard/Filters"
+import { useSelector } from "react-redux"
+
+let container
+
+jest.mock("react-redux", () => ({
+  useSelector: jest.fn(),
+}))
+jest.mock("components/ChartCard/ClearFilters", () => () => (
+  <mock-ClearFilters />
+))
+jest.mock("components/ChartCard/FilterTechnicalArea", () => () => (
+  <mock-FilterTechnicalArea />
+))
+jest.mock("components/ChartCard/FilterActionType", () => () => (
+  <mock-FilterActionType />
+))
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  document.body.removeChild(container)
+  container = null
+})
+
+describe("filters", () => {
+  describe("with the bar chart by technical area selected", () => {
+    beforeEach(() => {
+      useSelector.mockReturnValue(0)
+    })
+
+    it("renders the ClearFilters and FilterByTechnicalArea components", () => {
+      act(() => {
+        ReactDOM.render(<Filters />, container)
+      })
+      const foundClearFilters = container.querySelectorAll("mock-ClearFilters")
+      const foundFilterTechnicalArea = container.querySelectorAll(
+        "mock-FilterTechnicalArea"
+      )
+      const foundFilterActionType = container.querySelectorAll(
+        "mock-FilterActionType"
+      )
+
+      expect(foundClearFilters.length).toEqual(1)
+      expect(foundFilterTechnicalArea.length).toEqual(1)
+      expect(foundFilterActionType.length).toEqual(0)
+    })
+  })
+
+  describe("with the bar chart by action type selected", () => {
+    beforeEach(() => {
+      useSelector.mockReturnValue(1)
+    })
+
+    it("renders the checkbox as unchecked", () => {
+      act(() => {
+        ReactDOM.render(<Filters />, container)
+      })
+      const foundClearFilters = container.querySelectorAll("mock-ClearFilters")
+      const foundFilterTechnicalArea = container.querySelectorAll(
+        "mock-FilterTechnicalArea"
+      )
+      const foundFilterActionType = container.querySelectorAll(
+        "mock-FilterActionType"
+      )
+
+      expect(foundClearFilters.length).toEqual(1)
+      expect(foundFilterTechnicalArea.length).toEqual(0)
+      expect(foundFilterActionType.length).toEqual(1)
+    })
+  })
+})

--- a/test/javascript/src/components/ChartCard/InfoPane.test.js
+++ b/test/javascript/src/components/ChartCard/InfoPane.test.js
@@ -6,14 +6,12 @@ import InfoPane from "components/ChartCard/InfoPane"
 let container
 
 jest.mock("components/ChartCard/ActionCount", () => () => <mock-actioncount />)
-jest.mock("components/ChartCard/ClearFilters", () => () => (
-  <mock-clearfilters />
-))
+jest.mock("components/ChartCard/Filters", () => () => <mock-Filters />)
 jest.mock("components/ChartCard/DiseaseToggles", () => () => (
-  <mock-diseasetoggles />
+  <mock-DiseaseToggles />
 ))
 jest.mock("components/ChartCard/BarChartLegend", () => () => (
-  <mock-barchartlegend />
+  <mock-BarChartLegend />
 ))
 
 beforeEach(() => {
@@ -32,10 +30,10 @@ describe("InfoPane", () => {
       ReactDOM.render(<InfoPane />, container)
     })
 
-    const mockActionCount = container.querySelectorAll("mock-actioncount")
-    const mockClearFilter = container.querySelectorAll("mock-clearfilters")
-    const mockDiseaseToggles = container.querySelectorAll("mock-diseasetoggles")
-    const mockBarChartLegend = container.querySelectorAll("mock-barchartlegend")
+    const mockActionCount = container.querySelectorAll("mock-ActionCount")
+    const mockClearFilter = container.querySelectorAll("mock-Filters")
+    const mockDiseaseToggles = container.querySelectorAll("mock-DiseaseToggles")
+    const mockBarChartLegend = container.querySelectorAll("mock-BarChartLegend")
 
     expect(mockActionCount.length).toEqual(1)
     expect(mockClearFilter.length).toEqual(1)

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -146,6 +146,10 @@ class AppsTest < ApplicationSystemTestCase
         .count
     assert(count_deselected == count_bars - 1)
 
+    # make sure the filter dropdown has the correct value
+    dropdown_toggle = find('#dropdown-filter-technical-area .dropdown-toggle')
+    assert_equal 'IHR coordination', dropdown_toggle.text
+
     ##
     # reset and make sure no bar are deselected
     find('.clear-filters-component a').click
@@ -153,6 +157,10 @@ class AppsTest < ApplicationSystemTestCase
       all('#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected')
         .count
     assert(count_deselected == 0)
+
+    # make sure the filter dropdown has the correct value
+    dropdown_toggle = find('#dropdown-filter-technical-area .dropdown-toggle')
+    assert_equal 'All', dropdown_toggle.text
 
     ##
     # make sure Action Type tab has a legend
@@ -170,9 +178,14 @@ class AppsTest < ApplicationSystemTestCase
       all('#tabContentForActionType .ct-series-b .ct-bar.ct-deselected').count
     assert(count_deselected == count_bars - 1)
 
+    # make sure the filter dropdown has the correct value
+    dropdown_toggle = find('#dropdown-filter-action-type .dropdown-toggle')
+    assert_equal 'Assessment and Data Use', dropdown_toggle.text
+
     ##
-    # reset and make sure no bar are deselected
-    find('.clear-filters-component a').click
+    # click on 'All' in the dropdown toggle
+    find('#dropdown-filter-action-type').click
+    find('a', text: 'All').click
     count_deselected =
       all('#tabContentForActionType .ct-series-b .ct-bar.ct-deselected').count
     assert(count_deselected == 0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,6 +1573,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.13.8", "@babel/runtime@^7.6.3":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.12.5":
   version "7.13.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.2.tgz#9511c87d2808b2cf5fb9e9c5cf0d1ab789d75499"
@@ -1939,6 +1946,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@popperjs/core@^2.5.3":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
+  integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
+
 "@prettier/plugin-ruby@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-1.5.2.tgz#ca18cd7629ef0a3dec18b8dfbe7aba3d33a2e855"
@@ -2004,6 +2016,19 @@
     redux "^4.0.0"
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
+
+"@restart/context@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@restart/context/-/context-2.1.4.tgz#a99d87c299a34c28bd85bb489cb07bfd23149c02"
+  integrity sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==
+
+"@restart/hooks@^0.3.25", "@restart/hooks@^0.3.26":
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.3.26.tgz#ade155a7b0b014ef1073391dda46972c3a14a129"
+  integrity sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==
+  dependencies:
+    lodash "^4.17.20"
+    lodash-es "^4.17.20"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -2190,6 +2215,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/classnames@^2.2.10":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -2215,6 +2245,11 @@
   integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   dependencies:
     "@types/node" "*"
+
+"@types/invariant@^2.2.33":
+  version "2.2.34"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.34.tgz#05e4f79f465c2007884374d4795452f995720bbe"
+  integrity sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.2"
@@ -2273,15 +2308,46 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.0.tgz#dc85454b953178cc6043df5208b9e949b54a3bc4"
   integrity sha512-/rM+sWiuOZ5dvuVzV37sUuklsbg+JPOP8d+nNFlo2ZtfpzPiPvh1/gc8liWOLBqe+sR+ZM7guPaIcTt6UZTo7Q==
 
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-transition-group@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@>=16.9.11", "@types/react@>=16.9.35":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3535,6 +3601,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -4133,6 +4204,11 @@ csstype@^2.5.7, csstype@^2.6.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
+csstype@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
+  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4384,6 +4460,14 @@ dom-helpers@^5.0.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^2.6.7"
+
+dom-helpers@^5.1.2, dom-helpers@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -6994,6 +7078,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -8996,6 +9085,14 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+prop-types-extra@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
+  integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^4.0.0"
+
 prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -9153,6 +9250,30 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-bootstrap@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-1.5.2.tgz#07dabec53d10491a520c49f102170b440fa89008"
+  integrity sha512-mGKPY5+lLd7Vtkx2VFivoRkPT4xAHazuFfIhJLTEgHlDfIUSePn7qrmpZe5gXH9zvHV0RsBaQ9cLfXjxnZrOpA==
+  dependencies:
+    "@babel/runtime" "^7.13.8"
+    "@restart/context" "^2.1.4"
+    "@restart/hooks" "^0.3.26"
+    "@types/classnames" "^2.2.10"
+    "@types/invariant" "^2.2.33"
+    "@types/prop-types" "^15.7.3"
+    "@types/react" ">=16.9.35"
+    "@types/react-transition-group" "^4.4.1"
+    "@types/warning" "^3.0.0"
+    classnames "^2.2.6"
+    dom-helpers "^5.1.2"
+    invariant "^2.2.4"
+    prop-types "^15.7.2"
+    prop-types-extra "^1.1.0"
+    react-overlays "^5.0.0"
+    react-transition-group "^4.4.1"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
+
 react-chartist@^0.14.4:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/react-chartist/-/react-chartist-0.14.4.tgz#a70bdc78a92a7208973cab4253e177e99dc7bd29"
@@ -9177,7 +9298,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9186,6 +9307,25 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-overlays@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-5.0.0.tgz#b50351de194dda0706b40f9632d261c9f0011c4c"
+  integrity sha512-TKbqfAv23TFtCJ2lzISdx76p97G/DP8Rp4TOFdqM9n8GTruVYgE3jX7Zgb8+w7YJ18slTVcDTQ1/tFzdCqjVhA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@popperjs/core" "^2.5.3"
+    "@restart/hooks" "^0.3.25"
+    "@types/warning" "^3.0.0"
+    dom-helpers "^5.2.0"
+    prop-types "^15.7.2"
+    uncontrollable "^7.0.0"
+    warning "^4.0.3"
 
 react-redux@^7.2.0:
   version "7.2.0"
@@ -9222,7 +9362,7 @@ react-test-renderer@^16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-transition-group@^4.3.0:
+react-transition-group@^4.3.0, react-transition-group@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -10869,6 +11009,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+uncontrollable@^7.0.0, uncontrollable@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.2.1.tgz#1fa70ba0c57a14d5f78905d533cf63916dc75738"
+  integrity sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@types/react" ">=16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -11100,6 +11250,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.0, warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
[#177255183]

- new components Filters, FilterTechnicalArea, FilterActionType
- added actions for deselectActionType and deselectTechnicalArea
- helper function makeDropdownItem
- fixed some subtle state bugs in the UI reducers for DESELECT_ACTION_TYPE and CLEAR_FILTERS
- added system tests for the filter dropdowns on both technical area and action type charts
- relying on system tests for FilterTechnicalArea and FilterActionType, unable to unit test because of the Dropdown.Toggle, Dropdown.Menu, Dropdown.Item subcomponents that couldn't mock, relying on system tests for these components
- down-caret.svg in the Dropdown.Toggle

# Screenshots
![Screen Shot 2021-03-18 at 7 57 31 PM](https://user-images.githubusercontent.com/9426/111725491-66cf6480-8824-11eb-834f-3be5d7da4cd8.png)
![Screen Shot 2021-03-18 at 7 57 47 PM](https://user-images.githubusercontent.com/9426/111725500-69ca5500-8824-11eb-99c1-9da3be4664f6.png)

