### PR TITLE
Add multi-select drop down for action type and technical area filters respective on tabs [#177255183]

### DIFF
--- a/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
+++ b/app/javascript/src/components/ChartCard/BarChartByTechnicalArea.js
@@ -96,7 +96,7 @@ class BarChartByTechnicalArea extends React.Component {
       axisY: {
         // show multiples of 10
         labelInterpolationFnc: function (value) {
-          return value % 10 == 0 ? value : null
+          return value % 10 === 0 ? value : null
         },
       },
     }

--- a/app/javascript/src/components/ChartCard/FilterTechnicalArea.js
+++ b/app/javascript/src/components/ChartCard/FilterTechnicalArea.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { useDispatch, useSelector } from "react-redux"
 import {
+  getAllTechnicalAreas,
   getPlanChartLabels,
   getSelectedChartTabIndex,
   getSelectedTechnicalAreaId,
@@ -19,6 +20,7 @@ const FilterTechnicalArea = () => {
   const selectedTechnicalAreaId = useSelector((state) =>
     getSelectedTechnicalAreaId(state)
   )
+  const technicalAreas = useSelector((state) => getAllTechnicalAreas(state))
   const barChartLabels = useSelector((state) => getPlanChartLabels(state))[
     selectedChartTabIndex
   ]
@@ -28,14 +30,19 @@ const FilterTechnicalArea = () => {
     if (eventKey === "ALL") {
       dispatch(deselectTechnicalArea())
     } else {
-      dispatch(selectTechnicalArea(parseInt(eventKey, 10)))
+      const technicalAreaId = technicalAreas[parseInt(eventKey, 10)].id
+      dispatch(selectTechnicalArea(technicalAreaId))
     }
   }
 
   const allItem = makeDropdownItem("All", "ALL")
   const items = barChartLabels.map((label, i) => makeDropdownItem(label, i + 1))
   const selectedText = selectedTechnicalAreaId
-    ? barChartLabels[selectedTechnicalAreaId - 1]
+    ? barChartLabels[
+        technicalAreas.findIndex(
+          (technicalArea) => technicalArea.id === selectedTechnicalAreaId
+        )
+      ]
     : "All"
 
   return (

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -280,6 +280,7 @@ class AppsTest < ApplicationSystemTestCase
     click_on('email@example.com')
     click_on('My Plans')
     assert page.has_content?('Saved Nigeria Plan 789')
+    sleep 0.2
     click_on('Saved Nigeria Plan 789')
     sleep 0.2
     assert page.has_content?('National Legislation, Policy and Financing')


### PR DESCRIPTION
- fix bug with selecting a technical area in FilterTechnicalArea to look up it's position by id in the technicalAreas array, and the inverse looking up the selected technical area in the dropdown list by technicalArea.id when a bar is clicked, because technical area ids are only 1 based on development environments
- fixed a syntax warning in BarChartByTechnicalArea.js
- added a sleep 0.2 to another apps_test.rb that was having issues locally

