### PR TITLE
Move filters/actions above chart, move legend below

### DIFF
--- a/app/assets/stylesheets/plan.scss
+++ b/app/assets/stylesheets/plan.scss
@@ -271,6 +271,7 @@
       position: relative;
       padding-top: 0.25em;
       padding-left: 1.8em;
+      margin-left: 2.8em;
     }
 
     li:before {

--- a/app/javascript/src/components/ChartCard/ActionCount.js
+++ b/app/javascript/src/components/ChartCard/ActionCount.js
@@ -8,7 +8,7 @@ const ActionCount = () => {
   )
 
   return (
-    <div className="col-auto row action-count-component d-flex flex-column px-0">
+    <div className="col-6 col-xl-12 d-flex flex-column action-count-component">
       <div className="col-auto count">{countOfPlanActionIds}</div>
       <div className="col-auto label">Actions</div>
     </div>

--- a/app/javascript/src/components/ChartCard/BarChartLegend.js
+++ b/app/javascript/src/components/ChartCard/BarChartLegend.js
@@ -17,7 +17,7 @@ const BarChartLegend = () => {
 
   return (
     <div className="row py-2 px-4">
-      <ul className="ct-legend list-group list-group-horizontal col px-1">
+      <ul className="ct-legend list-group list-group-horizontal-md col px-1">
         <li className="ct-series-health-security">Health security</li>
         {diseaseLabelsHTML}
       </ul>

--- a/app/javascript/src/components/ChartCard/BarChartLegend.js
+++ b/app/javascript/src/components/ChartCard/BarChartLegend.js
@@ -16,11 +16,8 @@ const BarChartLegend = () => {
   })
 
   return (
-    <div className="row card d-flex flex-column px-2 py-2 m-0">
-      <div className="col">
-        <strong>Key</strong>
-      </div>
-      <ul className="ct-legend col m-0">
+    <div className="row py-2 px-4">
+      <ul className="ct-legend list-group list-group-horizontal col px-1">
         <li className="ct-series-health-security">Health security</li>
         {diseaseLabelsHTML}
       </ul>

--- a/app/javascript/src/components/ChartCard/BarChartLegendDiseaseLabel.js
+++ b/app/javascript/src/components/ChartCard/BarChartLegendDiseaseLabel.js
@@ -3,9 +3,7 @@ import PropTypes from "prop-types"
 
 const BarChartLegendDiseaseLabel = (props) => {
   const disease = props.disease
-  return (
-    <li className={`ct-series-${disease.name}`}>{disease.display} specific</li>
-  )
+  return <li className={`ct-series-${disease.name}`}>{disease.display}</li>
 }
 
 BarChartLegendDiseaseLabel.propTypes = {

--- a/app/javascript/src/components/ChartCard/ChartCard.js
+++ b/app/javascript/src/components/ChartCard/ChartCard.js
@@ -5,6 +5,7 @@ import { setSelectedChartTabIndex } from "../../config/actions"
 import BarChartByTechnicalArea from "./BarChartByTechnicalArea"
 import BarChartByActionType from "./BarChartByActionType"
 import InfoPane from "./InfoPane"
+import BarChartLegend from "./BarChartLegend"
 
 const tabSelector = 'a[data-toggle="tab"]'
 
@@ -24,6 +25,7 @@ const ChartCard = () => {
 
   return (
     <div className="plan card">
+      <InfoPane />
       <ul className="nav nav-tabs pt-3" role="tablist">
         <li className="nav-item px-2">
           <a
@@ -103,6 +105,7 @@ const ChartCard = () => {
             <InfoPane />
           </div>
         </div>
+        <BarChartLegend />
       </div>
     </div>
   )

--- a/app/javascript/src/components/ChartCard/ChartCard.js
+++ b/app/javascript/src/components/ChartCard/ChartCard.js
@@ -25,7 +25,6 @@ const ChartCard = () => {
 
   return (
     <div className="plan card">
-      <InfoPane />
       <ul className="nav nav-tabs pt-3" role="tablist">
         <li className="nav-item px-2">
           <a

--- a/app/javascript/src/components/ChartCard/DiseaseToggles.js
+++ b/app/javascript/src/components/ChartCard/DiseaseToggles.js
@@ -17,7 +17,7 @@ const DiseaseToggles = () => {
   })
 
   return (
-    <div className="row d-flex flex-column">
+    <div className="col d-flex flex-column">
       <div className="col">
         <strong>Show diseases</strong>
       </div>

--- a/app/javascript/src/components/ChartCard/Filters.js
+++ b/app/javascript/src/components/ChartCard/Filters.js
@@ -20,7 +20,7 @@ const Filters = () => {
 
   return (
     <>
-      <div className="row d-flex justify-content-between mb-1">
+      <div className="row d-flex justify-content-between mb-2">
         <div className="col">
           <strong>{title}</strong>
         </div>

--- a/app/javascript/src/components/ChartCard/InfoPane.js
+++ b/app/javascript/src/components/ChartCard/InfoPane.js
@@ -3,17 +3,14 @@ import ActionCount from "./ActionCount"
 import DiseaseToggles from "./DiseaseToggles"
 import Filters from "./Filters"
 
-// this is the best we have found so far:
-//   col-12 col-xl-auto
-// this is what it used to be before UI Rearrangement
-//   col-12 col-md
-
 const InfoPane = () => {
   return (
-    <div className="info-pane-component col-12 col-xl-4">
+    <div className="info-pane-component col-12 order-first col-xl-4 order-xl-last">
       <Filters />
-      <DiseaseToggles />
-      <ActionCount />
+      <div className="row">
+        <DiseaseToggles />
+        <ActionCount />
+      </div>
     </div>
   )
 }

--- a/app/javascript/src/components/ChartCard/InfoPane.js
+++ b/app/javascript/src/components/ChartCard/InfoPane.js
@@ -1,7 +1,6 @@
 import React from "react"
 import ActionCount from "./ActionCount"
 import DiseaseToggles from "./DiseaseToggles"
-import BarChartLegend from "./BarChartLegend"
 import Filters from "./Filters"
 
 // this is the best we have found so far:
@@ -14,7 +13,6 @@ const InfoPane = () => {
     <div className="info-pane-component col-12 col-xl-4">
       <Filters />
       <DiseaseToggles />
-      <BarChartLegend />
       <ActionCount />
     </div>
   )

--- a/app/views/pages/_reference_filter_by.haml
+++ b/app/views/pages/_reference_filter_by.haml
@@ -3,48 +3,94 @@
     .tab
       Filter by
   .card-body
-    %form{"data-target": "reference-library.filterForm"}
+    %form{"data-reference-library-target": "filterForm"}
       .form-row.flex-column
         .col
           %strong
             Technical Area
         .col
-          = select_tag :technical_area_id,
-              options_from_collection_for_select(@technical_areas, :id, :text),
-              {include_blank: true, prompt: "Type or select an option", class: "custom-select", "data-target": "reference-library.technicalAreaSelect"}
+          = select_tag :technical_area_id, options_from_collection_for_select(@technical_areas, :id, :text), {include_blank: true, prompt: "Type or select an option", class: "custom-select", "data-reference-library-target": "technicalAreaSelect"}
       .form-row.flex-column
         .col
           %strong
             Reference Type
         .col
-          %input{type: "checkbox", name: "briefing_notes", id: "briefing_notes", value: 1, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "briefing_notes",
+            id: "briefing_notes",
+            value: 1,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "briefing_notes"}
             Briefing Notes
           .w-100
-          %input{type: "checkbox", name: "case_studies", id: "case_studies", value: 2, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "case_studies",
+            id: "case_studies",
+            value: 2,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "case_studies"}
             Case Studies
           .w-100
-          %input{type: "checkbox", name: "examples", id: "examples", value: 3, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "examples",
+            id: "examples",
+            value: 3,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "examples"}
             Examples
           .w-100
-          %input{type: "checkbox", name: "guidelines", id: "guidelines", value: 4, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "guidelines",
+            id: "guidelines",
+            value: 4,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "guidelines"}
             Guidelines
           .w-100
-          %input{type: "checkbox", name: "manuals", id: "manuals", value: 5, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "manuals",
+            id: "manuals",
+            value: 5,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "manuals"}
             Manuals
           .w-100
-          %input{type: "checkbox", name: "templates", id: "templates", value: 6, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "templates",
+            id: "templates",
+            value: 6,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "templates"}
             Templates
           .w-100
-          %input{type: "checkbox", name: "tools", id: "tools", value: 7, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "tools",
+            id: "tools",
+            value: 7,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "tools"}
             Tools
           .w-100
-          %input{type: "checkbox", name: "training_packages", id: "training_packages", value: 8, "data-action": "reference-library#handleCheckboxToggle", "data-target": "reference-library.checkboxForReferenceType"}
+          %input{type: "checkbox",
+            name: "training_packages",
+            id: "training_packages",
+            value: 8,
+            "data-action": "reference-library#handleCheckboxToggle",
+            "data-reference-library-target": "checkboxForReferenceType",
+          }/
           %label{for: "training_packages"}
             Training Packages

--- a/app/views/pages/reference_library.html.haml
+++ b/app/views/pages/reference_library.html.haml
@@ -1,6 +1,9 @@
-- require 'csv'
+- require "csv"
 
-.reference-library{"data-controller": "reference-library", "data-reference-library-technical-areas": @technical_areas.to_json, "data-reference-library-template-selector": "#templateForFilterCirterionBadgePill"}
+.reference-library{"data-controller": "reference-library",
+  "data-reference-library-technical-areas": @technical_areas.to_json,
+  "data-reference-library-template-selector": "#templateForFilterCirterionBadgePill",
+}
   %h1 Reference Library
   .row.flex-wrap-reverse
     .col-lg-4.col-md-12
@@ -14,18 +17,17 @@
             |
           %strong
             Selections:
-          %span#filterCriteriaDisplay{"data-target": "reference-library.filterCriteriaDisplay"}
-
+          %span#filterCriteriaDisplay{"data-reference-library-target": "filterCriteriaDisplay"}
         %p
           %strong
             Showing:
-          %span{"data-target": "reference-library.documentCount"}
+          %span{"data-reference-library-target": "documentCount"}
       - @documents.each do |document|
         = render partial: "reference_document", locals: {document: document}
-
 %script#templateForFilterCirterionBadgePill{type: "text/html"}
   %span.badge.badge-pill
     {{text}}
-    %svg.x-close{"data-action": "click->reference-library\#{{methodName}}", xmlns: "http://www.w3.org/2000/svg"}
+    %svg.x-close{xmlns: "http://www.w3.org/2000/svg",
+      "data-action": "click->reference-library\#{{methodName}}"}
       %path{d: "M5.646 5.646a.5.5 0 000 .708l8 8a.5.5 0 00.708-.708l-8-8a.5.5 0 00-.708 0z"}
       %path{d: "M14.354 5.646a.5.5 0 010 .708l-8 8a.5.5 0 01-.708-.708l8-8a.5.5 0 01.708 0z"}

--- a/app/views/plans/_action.html.erb
+++ b/app/views/plans/_action.html.erb
@@ -1,6 +1,6 @@
 <div
   data-controller="action"
-  data-target="benchmark.action"
+  data-benchmark-target="action"
   data-action-id="<%= benchmark_action_id %>"
   data-action-bar-segment-index="<%= bar_segment_index %>"
   class="action row p-2 <%= action_type_classes %>"

--- a/app/views/plans/_benchmark_indicator.html.erb
+++ b/app/views/plans/_benchmark_indicator.html.erb
@@ -4,7 +4,7 @@
 
 <div
   data-controller="benchmark"
-  data-target="benchmark.self"
+  data-benchmark-target="self"
   data-benchmark-indicator-id="<%= benchmark_indicator.id %>"
   data-benchmark-indicator-display-abbrev="<%= benchmark_indicator.display_abbreviation %>"
   data-benchmark-action-row-template-selector="#action-row-template"
@@ -21,7 +21,7 @@
         class="close confirm-delete"
         type="button"
         data-action="benchmark#confirm"
-        data-target="benchmark.confirm"
+        data-benchmark-target="confirm"
       >
         <img src="/delete-button.svg" alt="Delete actions for this section" />
       </button>
@@ -29,7 +29,7 @@
       <button class="close delete"
               type="button"
               data-action="benchmark#deleteActionsForIndicator"
-              data-target="benchmark.delete"
+              data-benchmark-target="delete"
       >
         Really delete?
       </button>

--- a/app/views/plans/_technical_area.html.erb
+++ b/app/views/plans/_technical_area.html.erb
@@ -2,7 +2,7 @@
      id="technical-area-<%= benchmark_technical_area.sequence %>"
      title="<%= benchmark_technical_area.text %>"
      data-technical-area-id="<%= benchmark_technical_area.id %>"
-     data-target="plan.technicalAreaContainer"
+     data-plan-target="technicalAreaContainer"
 >
   <h3>
     <%= benchmark_technical_area.sequence %>.

--- a/app/views/start/_checkbox_for_technical_area.html.haml
+++ b/app/views/start/_checkbox_for_technical_area.html.haml
@@ -1,3 +1,3 @@
 .text-nowrap
-  = check_box_tag "get_started_form[technical_area_ids][]", technical_area.id, false, {class: "form-check-inline", id: "technical_area_id_#{technical_area.id}", "data-target": "get-started.checkboxForTechnicalArea"}
+  = check_box_tag "get_started_form[technical_area_ids][]", technical_area.id, false, {class: "form-check-inline", id: "technical_area_id_#{technical_area.id}", "data-get-started-target": "checkboxForTechnicalArea"}
   %label{for: "technical_area_id_#{technical_area.id}"}= technical_area.text

--- a/app/views/start/index.html.haml
+++ b/app/views/start/index.html.haml
@@ -5,7 +5,7 @@
       .form-row
         .col-6
           %h4 1. Select your country
-          = form.select :country_id, options_from_collection_for_select(@countries, :id, :name, @get_started_form.country_id), {include_blank: true, prompt: "Type or select an option"}, {class: "custom-select", "data-target": "get-started.countrySelect", required: true}
+          = form.select :country_id, options_from_collection_for_select(@countries, :id, :name, @get_started_form.country_id), {include_blank: true, prompt: "Type or select an option"}, {class: "custom-select", "data-get-started-target": "countrySelect", required: true}
           .invalid-feedback.my-3 Please choose a country.
       .form-row
         .col-2

--- a/app/views/start/show.html.haml
+++ b/app/views/start/show.html.haml
@@ -19,19 +19,27 @@
                 = form.radio_button :assessment_type, AssessmentPublication::NAMED_IDS.first, class: "form-check-input", required: true, "data-action": "get-started#selectAssessmentJee1"
                 = form.label :assessment_type, "Joint External Evaluation (JEE)", value: AssessmentPublication::NAMED_IDS.first, class: "form-check-label"
                 .invalid-feedback Please choose an assessment.
-              .plan-by-technical-area-container{"data-target": "get-started.planByTechnicalAreasContainerForJee1", style: "display: none"}
+              .plan-by-technical-area-container{ style: "display: none",
+                "data-get-started-target": "planByTechnicalAreasContainerForJee1",
+              }
                 %label
-                  %input{type: "checkbox", name: "get_started_form[plan_by_technical_ids]", value: 1, "data-action": "get-started#toggleTechnicalAreasForJee1"}
+                  %input{ type: "checkbox",
+                    name: "get_started_form[plan_by_technical_ids]",
+                    value: 1,
+                    "data-action": "get-started#toggleTechnicalAreasForJee1",
+                  }
                     %em Optional:
                     Plan by technical area(s)
-                .collapse{"data-target": "get-started.cardOfTechnicalAreasForJee1"}
+                .collapse{"data-get-started-target": "cardOfTechnicalAreasForJee1"}
                   .col.card
                     .row
                       .col
-                        %a{href: "#", "data-action": "get-started#selectAllTechnicalAreasForJee1"}
+                        %a{ href: "#",
+                          "data-action": "get-started#selectAllTechnicalAreasForJee1" }
                           Select all
                         |
-                        %a{href: "#", "data-action": "get-started#deselectAllTechnicalAreasForJee1"}
+                        %a{ href: "#",
+                          "data-action": "get-started#deselectAllTechnicalAreasForJee1" }
                           Deselect all
                     .row
                       - col1_count_for_jee1 = ((@technical_areas_jee1.size + 1) / 2).floor
@@ -46,19 +54,26 @@
                 = form.radio_button :assessment_type, AssessmentPublication::NAMED_IDS.second, class: "form-check-input", required: true, "data-action": "get-started#selectAssessmentSpar2018"
                 = form.label :assessment_type, "State Party Annual Report (SPAR)", value: AssessmentPublication::NAMED_IDS.second, class: "form-check-label"
                 .invalid-feedback Please choose an assessment.
-              .plan-by-technical-area-container{"data-target": "get-started.planByTechnicalAreasContainerForSpar2018", style: "display: none"}
+              .plan-by-technical-area-container{ style: "display: none",
+                "data-get-started-target": "planByTechnicalAreasContainerForSpar2018" }
                 %label
-                  %input{type: "checkbox", name: "get_started_form[plan_by_technical_ids]", value: 1, "data-action": "get-started#toggleTechnicalAreasForSpar2018"}
+                  %input{ type: "checkbox",
+                    name: "get_started_form[plan_by_technical_ids]",
+                    value: 1,
+                    "data-action": "get-started#toggleTechnicalAreasForSpar2018",
+                  }
                     %em Optional:
                     Plan by technical area(s)
-                .collapse{"data-target": "get-started.cardOfTechnicalAreasForSpar2018"}
+                .collapse{"data-get-started-target": "cardOfTechnicalAreasForSpar2018"}
                   .col.card
                     .row
                       .col
-                        %a{href: "#", "data-action": "get-started#selectAllTechnicalAreasForSpar2018"}
+                        %a{ href: "#",
+                            "data-action": "get-started#selectAllTechnicalAreasForSpar2018" }
                           Select all
                         |
-                        %a{href: "#", "data-action": "get-started#deselectAllTechnicalAreasForSpar2018"}
+                        %a{ href: "#",
+                            "data-action": "get-started#deselectAllTechnicalAreasForSpar2018" }
                           Deselect all
                     .row
                       - col1_count_for_spar2018 = ((@technical_areas_spar_2018.size + 1) / 2).floor
@@ -104,4 +119,4 @@
             %div{style: "height: 75px"}
       .form-row
         .col-2
-          = form.submit "Next", class: "btn btn-primary", "data-target": "get-started.submit"
+          = form.submit "Next", class: "btn btn-primary", "data-get-started-target": "submit"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "prettier": {
     "semi": false,
-    "preferSingleQuotes": false,
-    "addTrailingCommas": true
+    "singleQuote": false,
+    "rubySingleQuote": false
   },
   "scripts": {
     "postinstall": "husky install",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix",
-    "*.{js,jsx,css,scss,md,rb,haml}": "prettier --write"
+    "*.{js,jsx,css,scss,md,rb}": "prettier --write"
   }
 }

--- a/test/javascript/checkbox_list_controller.test.js
+++ b/test/javascript/checkbox_list_controller.test.js
@@ -1,4 +1,4 @@
-import { Application, Controller } from "stimulus"
+import { Application } from "stimulus"
 import CheckboxListController from "checkbox_list_controller"
 import $ from "jquery"
 jest.mock("jquery")
@@ -27,7 +27,7 @@ describe("CheckboxListController", () => {
             id="item-1"
             value="item-1"
             data-action="click->checkbox-list#updateState"
-            data-target="checkbox-list.listItem" />
+            data-checkbox-list-target="listItem" />
           <label for="item-1">Item 1</label>
         </li>
         <li>
@@ -35,7 +35,7 @@ describe("CheckboxListController", () => {
             name="selection"
             id="item-2"
             data-action="click->checkbox-list#updateState"
-            data-target="checkbox-list.listItem" />
+            data-checkbox-list-target="listItem" />
             value="item-2" />
           <label for="item-2">Item 2</label>
         </li>
@@ -44,12 +44,12 @@ describe("CheckboxListController", () => {
             name="selection"
             id="item-3"
             data-action="click->checkbox-list#updateState"
-            data-target="checkbox-list.listItem" />
+            data-checkbox-list-target="listItem" />
             value="item-3" />
           <label for="item-3">Item 3</label>
         </li>
         <input type="button" id="submit"
-          data-target="checkbox-list.submitForm" />
+          data-checkbox-list-target="submitForm" />
         </ul>
       </div>
     `

--- a/test/javascript/score_and_goal_controller.test.js
+++ b/test/javascript/score_and_goal_controller.test.js
@@ -1,4 +1,4 @@
-import { Application, Controller } from "stimulus"
+import { Application } from "stimulus"
 import ScoreController from "score_controller"
 import ScoreAndGoalController from "score_and_goal_controller"
 import $ from "jquery"
@@ -14,10 +14,10 @@ describe("ScoreAndGoalController", () => {
       document.body.innerHTML = `
       <div data-controller="score">
         <div data-controller="score-and-goal">
-          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+          <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
             <input type="number" data-action="change->score-and-goal#validatePair" id="score1" />
             <input type="number" data-action="change->score-and-goal#validatePair" id="score1_goal" data-goal="true" />
-            <input id="submit" type="submit" data-target="score.submitButton" />
+            <input id="submit" type="submit" data-score-target="submitButton" />
           </form>
         </div>
       </div>
@@ -46,10 +46,10 @@ describe("ScoreAndGoalController", () => {
       document.body.innerHTML = `
       <div data-controller="score">
         <div data-controller="score-and-goal">
-          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
+          <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
             <input type="number" data-action="change->score-and-goal#validatePair" id="score1" />
             <input type="number" data-action="change->score-and-goal#validatePair" id="score1_goal" data-goal="true" />
-            <input id="submit" type="submit" data-target="score.submitButton" />
+            <input id="submit" type="submit" data-score-target="submitButton" />
           </form>
         </div>
       </div>
@@ -114,10 +114,10 @@ describe("ScoreAndGoalController", () => {
       document.body.innerHTML = `
       <div data-controller="score">
         <div data-controller="score-and-goal">
-          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" id="score1" />
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  id="score1_goal" data-goal="true" />
-            <input id="submit" type="submit" data-target="score.submitButton" />
+          <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="score" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="goal"  id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-score-target="submitButton" />
           </form>
         </div>
       </div>
@@ -167,10 +167,10 @@ describe("ScoreAndGoalController", () => {
       document.body.innerHTML = `
       <div data-controller="score">
         <div data-controller="score-and-goal">
-          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" data-toggle="tooltip" placement="top" id="score1" />
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  data-toggle="tooltip" placement="top" id="score1_goal" data-goal="true" />
-            <input id="submit" type="submit" data-target="score.submitButton" />
+          <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="score" data-toggle="tooltip" placement="top" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="goal"  data-toggle="tooltip" placement="top" id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-score-target="submitButton" />
           </form>
         </div>
       </div>
@@ -266,10 +266,10 @@ describe("ScoreAndGoalController", () => {
       document.body.innerHTML = `
       <div data-controller="score">
         <div data-controller="score-and-goal">
-          <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.score" id="score1" />
-            <input type="number" data-action="change->score-and-goal#validatePair" data-target="score-and-goal.goal"  id="score1_goal" data-goal="true" />
-            <input id="submit" type="submit" data-target="score.submitButton" />
+          <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="score" id="score1" />
+            <input type="number" data-action="change->score-and-goal#validatePair" data-score-and-goal-target="goal"  id="score1_goal" data-goal="true" />
+            <input id="submit" type="submit" data-score-target="submitButton" />
           </form>
         </div>
       </div>

--- a/test/javascript/score_controller.test.js
+++ b/test/javascript/score_controller.test.js
@@ -1,4 +1,4 @@
-import { Application, Controller } from "stimulus"
+import { Application } from "stimulus"
 import ScoreController from "score_controller"
 
 describe("ScoreController", () => {
@@ -25,8 +25,8 @@ describe("ScoreController", () => {
     beforeEach(() => {
       document.body.innerHTML = `
       <div data-controller="score">
-        <form data-target="score.form" data-action="submit->score#submit" data-type="jee1">
-          <input id="submit" type="submit" data-target="score.submitButton" />
+        <form data-score-target="form" data-action="submit->score#submit" data-type="jee1">
+          <input id="submit" type="submit" data-score-target="submitButton" />
         </form>
       </div>
       `

--- a/test/javascript/src/components/ChartCard/BarChartLegendDiseaseLabel.test.js
+++ b/test/javascript/src/components/ChartCard/BarChartLegendDiseaseLabel.test.js
@@ -20,7 +20,7 @@ afterEach(() => {
 })
 
 describe("with a disease", () => {
-  const disease = { id: 1, name: "influenza", display: "Influenza" }
+  const disease = { id: 1, name: "influenza", display: "Influenza specific" }
   beforeEach(() => {
     act(() => {
       ReactDOM.render(

--- a/test/javascript/src/components/ChartCard/ChartCard.test.js
+++ b/test/javascript/src/components/ChartCard/ChartCard.test.js
@@ -18,6 +18,9 @@ jest.mock("components/ChartCard/BarChartByActionType", () => () => (
   <mock-BarChartByActionType />
 ))
 jest.mock("components/ChartCard/InfoPane", () => () => <mock-InfoPane />)
+jest.mock("components/ChartCard/BarChartLegend", () => () => (
+  <mock-BarChartLegend />
+))
 
 let container
 

--- a/test/javascript/src/components/ChartCard/InfoPane.test.js
+++ b/test/javascript/src/components/ChartCard/InfoPane.test.js
@@ -10,9 +10,6 @@ jest.mock("components/ChartCard/Filters", () => () => <mock-Filters />)
 jest.mock("components/ChartCard/DiseaseToggles", () => () => (
   <mock-DiseaseToggles />
 ))
-jest.mock("components/ChartCard/BarChartLegend", () => () => (
-  <mock-BarChartLegend />
-))
 
 beforeEach(() => {
   container = document.createElement("div")
@@ -33,11 +30,9 @@ describe("InfoPane", () => {
     const mockActionCount = container.querySelectorAll("mock-ActionCount")
     const mockClearFilter = container.querySelectorAll("mock-Filters")
     const mockDiseaseToggles = container.querySelectorAll("mock-DiseaseToggles")
-    const mockBarChartLegend = container.querySelectorAll("mock-BarChartLegend")
 
     expect(mockActionCount.length).toEqual(1)
     expect(mockClearFilter.length).toEqual(1)
     expect(mockDiseaseToggles.length).toEqual(1)
-    expect(mockBarChartLegend.length).toEqual(1)
   })
 })

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -1,43 +1,43 @@
-require File.expand_path('./test/application_system_test_case')
+require File.expand_path("./test/application_system_test_case")
 
 class AppsTest < ApplicationSystemTestCase
-  test 'happy path for Nigeria JEE 1.0' do
+  test "happy path for Nigeria JEE 1.0" do
     visit root_url
-    click_on('Get Started') until current_path == '/get-started'
+    click_on("Get Started") until current_path == "/get-started"
     assert page.has_content?("LET'S GET STARTED")
-    select_from_chosen('Nigeria', from: 'get_started_form_country_id')
-    click_on('Next')
+    select_from_chosen("Nigeria", from: "get_started_form_country_id")
+    click_on("Next")
 
-    choose 'Joint External Evaluation (JEE)'
-    choose '1 year plan'
-    click_on('Next')
+    choose "Joint External Evaluation (JEE)"
+    choose "1 year plan"
+    click_on("Next")
 
     ##
     # turn up on the Goal-setting page for the selected options and hit save
-    assert_current_path('/plan/goals/Nigeria/jee1/1-year')
-    assert page.has_content?('JEE SCORES')
+    assert_current_path("/plan/goals/Nigeria/jee1/1-year")
+    assert page.has_content?("JEE SCORES")
     assert page.has_content?(
-             'P.1.1 Legislation, laws, regulations, administrative requirements, policies or other government instruments in place are sufficient for implementation of IHR (2005)'
+             "P.1.1 Legislation, laws, regulations, administrative requirements, policies or other government instruments in place are sufficient for implementation of IHR (2005)"
            )
     assert page.has_content?(
-             'RE.2 Enabling environment in place for management of radiation emergencies'
+             "RE.2 Enabling environment in place for management of radiation emergencies"
            )
-    assert_equal '1', find('#plan_indicators_jee1_ind_p11').value
-    assert_equal '2', find('#plan_indicators_jee1_ind_p11_goal').value
-    find('#new_plan input[type=submit]').trigger(:click)
+    assert_equal "1", find("#plan_indicators_jee1_ind_p11").value
+    assert_equal "2", find("#plan_indicators_jee1_ind_p11_goal").value
+    find("#new_plan input[type=submit]").trigger(:click)
 
     ##
     # wind up on the View Plan page after the plan has been saved, and then make an edit
     assert_current_path(%r{^\/plans\/\d+$})
-    assert_equal 'Nigeria draft plan', find('#plan_name').value
-    assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '337', find('.action-count-component .count').text
-    assert_selector('#technical-area-1') # the first one
-    assert_selector('#technical-area-3') # the last one
-    assert_selector('.nudge-container') do
+    assert_equal "Nigeria draft plan", find("#plan_name").value
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "337", find(".action-count-component .count").text
+    assert_selector("#technical-area-1") # the first one
+    assert_selector("#technical-area-3") # the last one
+    assert_selector(".nudge-container") do
       assert page.has_content?(
                # nudge content for 1-year plan
-               'Focus on no more than 2-3 actions per technical area'
+               "Focus on no more than 2-3 actions per technical area"
              )
     end
 
@@ -51,178 +51,172 @@ class AppsTest < ApplicationSystemTestCase
       "line[data-original-title*=\"Antimicrobial Resistance\"]",
       match: :first
     ).click
-    assert_selector('#technical-area-3') # the last one
-    assert_no_selector('#technical-area-1') # the first one
+    assert_selector("#technical-area-3") # the last one
+    assert_no_selector("#technical-area-1") # the first one
 
     # un-filter to show all
-    find('.clear-filters-component a').click
-    assert_selector('#technical-area-1')
-    assert_selector('#technical-area-18')
+    find(".clear-filters-component a").click
+    assert_selector("#technical-area-1")
+    assert_selector("#technical-area-18")
 
     # edit the plan name and hit save button
-    find('#plan_name').fill_in with: 'Saved Nigeria Plan 789'
-    find('input[type=submit]').trigger(:click)
+    find("#plan_name").fill_in with: "Saved Nigeria Plan 789"
+    find("input[type=submit]").trigger(:click)
 
     ##
     # wind up on sign-in page and go to create an account
-    assert_current_path('/users/sign_in')
-    click_link('Create an account')
+    assert_current_path("/users/sign_in")
+    click_link("Create an account")
 
     ##
     # wind up on create account page
-    assert_current_path('/users/sign_up')
+    assert_current_path("/users/sign_up")
     sleep 0.1
-    find('#user_email').fill_in with: 'email@example.com'
-    find('#user_password').fill_in with: '123123'
-    find('#user_password_confirmation').fill_in with: '123123'
-    find('#new_user input[type=submit]').trigger(:click)
+    find("#user_email").fill_in with: "email@example.com"
+    find("#user_password").fill_in with: "123123"
+    find("#user_password_confirmation").fill_in with: "123123"
+    find("#new_user input[type=submit]").trigger(:click)
 
     ##
     # wind up on create account page
-    assert_current_path('/plans')
-    assert page.has_content?('Welcome! You have signed up successfully.')
-    assert page.has_content?('Saved Nigeria Plan 789') # ugh without this form field(s) dont get filled
+    assert_current_path("/plans")
+    assert page.has_content?("Welcome! You have signed up successfully.")
+    assert page.has_content?("Saved Nigeria Plan 789") # ugh without this form field(s) dont get filled
   end
 
-  test 'happy path for Nigeria JEE 1.0 with influenza and cholera' do
+  test "happy path for Nigeria JEE 1.0 with influenza and cholera" do
     ##
     # visit home page
     visit root_url
-    click_on('Get Started') until current_path == '/get-started'
+    click_on("Get Started") until current_path == "/get-started"
     assert page.has_content?("LET'S GET STARTED")
 
-    select_from_chosen('Nigeria', from: 'get_started_form_country_id')
-    click_on('Next')
-    choose 'Joint External Evaluation (JEE)'
-    choose '1 year plan'
-    check 'Optional: Influenza planning'
-    check 'Optional: Cholera planning'
-    click_on('Next')
+    select_from_chosen("Nigeria", from: "get_started_form_country_id")
+    click_on("Next")
+    choose "Joint External Evaluation (JEE)"
+    choose "1 year plan"
+    check "Optional: Influenza planning"
+    check "Optional: Cholera planning"
+    click_on("Next")
 
     ##
     # turn up on the Goal-setting page for the selected options and hit save
-    assert_current_path('/plan/goals/Nigeria/jee1/1-year?diseases=1-2')
-    assert page.has_content?('JEE SCORES')
+    assert_current_path("/plan/goals/Nigeria/jee1/1-year?diseases=1-2")
+    assert page.has_content?("JEE SCORES")
     assert page.has_content?(
-             'P.1.1 Legislation, laws, regulations, administrative requirements, policies or other government instruments in place are sufficient for implementation of IHR (2005)'
+             "P.1.1 Legislation, laws, regulations, administrative requirements, policies or other government instruments in place are sufficient for implementation of IHR (2005)"
            )
     assert page.has_content?(
-             'RE.2 Enabling environment in place for management of radiation emergencies'
+             "RE.2 Enabling environment in place for management of radiation emergencies"
            )
-    assert_equal '1', find('#plan_indicators_jee1_ind_p11').value
-    assert_equal '2', find('#plan_indicators_jee1_ind_p11_goal').value
-    find('#new_plan input[type=submit]').trigger(:click)
+    assert_equal "1", find("#plan_indicators_jee1_ind_p11").value
+    assert_equal "2", find("#plan_indicators_jee1_ind_p11_goal").value
+    find("#new_plan input[type=submit]").trigger(:click)
 
     ##
     # wind up on the View Plan page after the plan has been saved, and then make an edit
     assert_current_path(%r{^\/plans\/\d+$})
-    assert_equal 'Nigeria draft plan', find('#plan_name').value
-    assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '337', find('.action-count-component .count').text
-    assert_selector('#technical-area-1') # the first one
-    assert_selector('#technical-area-3') # the last one
-    assert_selector('.nudge-container') do
+    assert_equal "Nigeria draft plan", find("#plan_name").value
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "337", find(".action-count-component .count").text
+    assert_selector("#technical-area-1") # the first one
+    assert_selector("#technical-area-3") # the last one
+    assert_selector(".nudge-container") do
       assert page.has_content?(
                # nudge content for 1-year plan
-               'Focus on no more than 2-3 actions per technical area'
+               "Focus on no more than 2-3 actions per technical area"
              )
     end
 
     ##
     # Make sure there are the correct number of indicators with no capacity gap
-    indicators_no_capacity_gap = all('.benchmark-container .no-capacity-gap')
+    indicators_no_capacity_gap = all(".benchmark-container .no-capacity-gap")
     indicator_headings =
       indicators_no_capacity_gap.map do |indicator|
-        indicator.ancestor('.benchmark-container').find('.header').text
+        indicator.ancestor(".benchmark-container").find(".header").text
       end
     assert_equal(
       indicator_headings,
       [
-        'Benchmark 1.2: Financing is available for the implementation of IHR capacities',
-        'Benchmark 1.3: Financing available for timely response to public health emergencies',
-        'Benchmark 3.1: Effective multisectoral coordination on AMR',
-        'Benchmark 10.3: In-service trainings are available',
-        'Benchmark 12.1: Functional emergency response coordination is in place'
+        "Benchmark 1.2: Financing is available for the implementation of IHR capacities",
+        "Benchmark 1.3: Financing available for timely response to public health emergencies",
+        "Benchmark 3.1: Effective multisectoral coordination on AMR",
+        "Benchmark 10.3: In-service trainings are available",
+        "Benchmark 12.1: Functional emergency response coordination is in place"
       ]
     )
 
     # and make sure there are Add Action components for each of these indicators
     add_actions =
       indicators_no_capacity_gap.map do |indicator|
-        indicator.ancestor('.benchmark-container').find('.action-form')
+        indicator.ancestor(".benchmark-container").find(".action-form")
       end
     assert(add_actions.count == indicators_no_capacity_gap.count)
 
     ##
     # make sure Technical Area tab has a legend
-    find('#tabContentForTechnicalArea .ct-legend').has_content?(
-      'Influenza specific'
-    )
-    find('#tabContentForTechnicalArea .ct-legend').has_content?(
-      'Cholera specific'
-    )
+    find(".tab-content .ct-legend").has_content?("Influenza")
+    find(".tab-content .ct-legend").has_content?("Cholera")
 
     ##
     # click on one of the bars and make sure others are deselected
-    all('#tabContentForTechnicalArea .ct-series-a .ct-bar')[1].click
-    count_bars = all('#tabContentForTechnicalArea .ct-series-a .ct-bar').count
+    all("#tabContentForTechnicalArea .ct-series-a .ct-bar")[1].click
+    count_bars = all("#tabContentForTechnicalArea .ct-series-a .ct-bar").count
     count_deselected =
-      all('#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected')
+      all("#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected")
         .count
     assert(count_deselected == count_bars - 1)
 
     # make sure the filter dropdown has the correct value
-    dropdown_toggle = find('#dropdown-filter-technical-area .dropdown-toggle')
-    assert_equal 'IHR coordination', dropdown_toggle.text
+    dropdown_toggle = find("#dropdown-filter-technical-area .dropdown-toggle")
+    assert_equal "IHR coordination", dropdown_toggle.text
 
     ##
     # reset and make sure no bar are deselected
-    find('.clear-filters-component a').click
+    find(".clear-filters-component a").click
     count_deselected =
-      all('#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected')
+      all("#tabContentForTechnicalArea .ct-series-a .ct-bar.ct-deselected")
         .count
     assert(count_deselected == 0)
 
     # make sure the filter dropdown has the correct value
-    dropdown_toggle = find('#dropdown-filter-technical-area .dropdown-toggle')
-    assert_equal 'All', dropdown_toggle.text
+    dropdown_toggle = find("#dropdown-filter-technical-area .dropdown-toggle")
+    assert_equal "All", dropdown_toggle.text
 
     ##
     # make sure Action Type tab has a legend
-    find('#tabForActionType').click
-    find('#tabContentForActionType .ct-legend').has_content?(
-      'Influenza specific'
-    )
-    find('#tabContentForActionType .ct-legend').has_content?('Cholera specific')
+    find("#tabForActionType").click
+    find(".tab-content .ct-legend").has_content?("Influenza")
+    find(".tab-content .ct-legend").has_content?("Cholera")
 
     ##
     # click on one of the bars and make sure others are deselected
-    all('#tabContentForActionType .ct-series-b .ct-bar')[1].click
-    count_bars = all('#tabContentForActionType .ct-series-b .ct-bar').count
+    all("#tabContentForActionType .ct-series-b .ct-bar")[1].click
+    count_bars = all("#tabContentForActionType .ct-series-b .ct-bar").count
     count_deselected =
-      all('#tabContentForActionType .ct-series-b .ct-bar.ct-deselected').count
+      all("#tabContentForActionType .ct-series-b .ct-bar.ct-deselected").count
     assert(count_deselected == count_bars - 1)
 
     # make sure the filter dropdown has the correct value
-    dropdown_toggle = find('#dropdown-filter-action-type .dropdown-toggle')
-    assert_equal 'Assessment and Data Use', dropdown_toggle.text
+    dropdown_toggle = find("#dropdown-filter-action-type .dropdown-toggle")
+    assert_equal "Assessment and Data Use", dropdown_toggle.text
 
     ##
     # click on 'All' in the dropdown toggle
-    find('#dropdown-filter-action-type').click
-    find('a', text: 'All').click
+    find("#dropdown-filter-action-type").click
+    find("a", text: "All").click
     count_deselected =
-      all('#tabContentForActionType .ct-series-b .ct-bar.ct-deselected').count
+      all("#tabContentForActionType .ct-series-b .ct-bar.ct-deselected").count
     assert(count_deselected == 0)
 
     ##
     # go back to technical area tab
-    find('#tabForTechnicalArea').click
+    find("#tabForTechnicalArea").click
 
-    assert_selector('#technical-area-1') do
+    assert_selector("#technical-area-1") do
       assert page.has_content?(
                # nudge content for 1-year plan
-               'government instruments relevant to pandemic influenza'
+               "government instruments relevant to pandemic influenza"
              )
     end
 
@@ -237,166 +231,166 @@ class AppsTest < ApplicationSystemTestCase
       "line[data-original-title*=\"Antimicrobial Resistance\"]",
       match: :first
     ).click
-    assert_selector('#technical-area-3') # the last one
-    assert_no_selector('#technical-area-1') # the first one
+    assert_selector("#technical-area-3") # the last one
+    assert_no_selector("#technical-area-1") # the first one
 
     # un-filter to show all
-    find('.clear-filters-component a').click
-    assert_selector('#technical-area-1')
-    assert_selector('#technical-area-18')
+    find(".clear-filters-component a").click
+    assert_selector("#technical-area-1")
+    assert_selector("#technical-area-18")
 
     # edit the plan name and hit save button
-    find('#plan_name').fill_in with: 'Saved Nigeria Plan 789'
-    find('input[type=submit]').trigger(:click)
+    find("#plan_name").fill_in with: "Saved Nigeria Plan 789"
+    find("input[type=submit]").trigger(:click)
 
     ##
     # wind up on sign-in page and go to create an account
-    assert_current_path('/users/sign_in')
-    click_link('Create an account')
+    assert_current_path("/users/sign_in")
+    click_link("Create an account")
 
     ##
     # wind up on create account page
-    assert_current_path('/users/sign_up')
+    assert_current_path("/users/sign_up")
     sleep 0.1
-    find('#user_email').fill_in with: 'email@example.com'
-    find('#user_password').fill_in with: '123123'
-    find('#user_password_confirmation').fill_in with: '123123'
-    find('#new_user input[type=submit]').trigger(:click)
+    find("#user_email").fill_in with: "email@example.com"
+    find("#user_password").fill_in with: "123123"
+    find("#user_password_confirmation").fill_in with: "123123"
+    find("#new_user input[type=submit]").trigger(:click)
 
     ##
     # make sure the plan was saved
-    assert_current_path('/plans')
-    assert page.has_content?('Welcome! You have signed up successfully.')
-    assert page.has_content?('Saved Nigeria Plan 789') # ugh without this form field(s) dont get filled
+    assert_current_path("/plans")
+    assert page.has_content?("Welcome! You have signed up successfully.")
+    assert page.has_content?("Saved Nigeria Plan 789") # ugh without this form field(s) dont get filled
 
     ##
     # make sure Turbolinks and the dropdown menu are working in both react and non-react contexts
-    click_on('WHO BENCHMARKS')
-    assert page.has_content?('BENCHMARKS FOR IHR CAPACITIES')
-    click_on('REFERENCE LIBRARY')
+    click_on("WHO BENCHMARKS")
+    assert page.has_content?("BENCHMARKS FOR IHR CAPACITIES")
+    click_on("REFERENCE LIBRARY")
     assert page.has_content?(
-             'Establishment of a Sentinel Laboratory-Based Antimicrobial Resistance Surveillance Network in Ethiopia'
+             "Establishment of a Sentinel Laboratory-Based Antimicrobial Resistance Surveillance Network in Ethiopia"
            )
-    click_on('email@example.com')
-    click_on('My Plans')
-    assert page.has_content?('Saved Nigeria Plan 789')
+    click_on("email@example.com")
+    click_on("My Plans")
+    assert page.has_content?("Saved Nigeria Plan 789")
     sleep 0.2
-    click_on('Saved Nigeria Plan 789')
+    click_on("Saved Nigeria Plan 789")
     sleep 0.2
-    assert page.has_content?('National Legislation, Policy and Financing')
-    click_on('email@example.com')
-    click_on('My Plans')
-    assert page.has_content?('Saved Nigeria Plan 789')
+    assert page.has_content?("National Legislation, Policy and Financing")
+    click_on("email@example.com")
+    click_on("My Plans")
+    assert page.has_content?("Saved Nigeria Plan 789")
 
     ##
     # delete the plan
-    click_link('Delete')
+    click_link("Delete")
     assert page.has_content?("You haven't started any plans yet")
   end
 
-  test 'happy path for Armenia SPAR 2018 5-year plan' do
+  test "happy path for Armenia SPAR 2018 5-year plan" do
     visit root_url
-    click_on('Get Started') until current_path == '/get-started'
+    click_on("Get Started") until current_path == "/get-started"
     assert page.has_content?("LET'S GET STARTED")
-    select_from_chosen('Armenia', from: 'get_started_form_country_id')
-    click_on('Next')
-    choose 'State Party Annual Report (SPAR)'
-    choose '5 year plan'
-    click_on('Next')
+    select_from_chosen("Armenia", from: "get_started_form_country_id")
+    click_on("Next")
+    choose "State Party Annual Report (SPAR)"
+    choose "5 year plan"
+    click_on("Next")
 
     ##
     # turn up on the plan goal-setting page
-    assert_current_path('/plan/goals/Armenia/spar_2018/5-year')
-    assert page.has_content?('SPAR SCORES')
+    assert_current_path("/plan/goals/Armenia/spar_2018/5-year")
+    assert page.has_content?("SPAR SCORES")
     assert page.has_content?(
-             'C4.1 Multisectoral collaboration mechanism for food safety events'
+             "C4.1 Multisectoral collaboration mechanism for food safety events"
            )
 
     # verify that the 5-year plan has set goal from 2 to 4
-    assert_equal '2', find('#plan_indicators_spar_2018_ind_c41').value
-    assert_equal '4', find('#plan_indicators_spar_2018_ind_c41_goal').value
-    find('#new_plan input[type=submit]').trigger(:click)
+    assert_equal "2", find("#plan_indicators_spar_2018_ind_c41").value
+    assert_equal "4", find("#plan_indicators_spar_2018_ind_c41_goal").value
+    find("#new_plan input[type=submit]").trigger(:click)
 
     ##
     # wind up on the View Plan page, make an edit, and save the plan
     assert_current_path(%r{^\/plans\/\d+$})
-    assert_equal 'Armenia draft plan', find('#plan_name').value
-    assert_equal 'Actions', find('.action-count-component .label').text
+    assert_equal "Armenia draft plan", find("#plan_name").value
+    assert_equal "Actions", find(".action-count-component .label").text
 
     # action count was 103 but became 98 along with refactoring changes, I think due to bug(s) fixed
-    assert_equal '209', find('.action-count-component .count').text
+    assert_equal "209", find(".action-count-component .count").text
     assert page.has_content?(
-             'Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors.'
+             "Document and disseminate information on the timely distribution and effective use of funds to increase health security (such as preventing or stopping the spread of disease), at the national and subnational levels in all relevant ministries or sectors."
            )
-    find('#plan_name').fill_in with: 'Saved Armenia Plan'
-    find('input[type=submit]').trigger(:click)
+    find("#plan_name").fill_in with: "Saved Armenia Plan"
+    find("input[type=submit]").trigger(:click)
 
     ##
     # wind up on the Sign In page, go to Create an Account
-    assert_current_path('/users/sign_in')
-    click_link('Create an account')
+    assert_current_path("/users/sign_in")
+    click_link("Create an account")
 
     ##
     # at the Create an Account page, fill and submit the form
-    assert_current_path('/users/sign_up')
+    assert_current_path("/users/sign_up")
     sleep 0.1
-    find('#user_email').fill_in with: 'email@example.com'
-    find('#user_password').fill_in with: '123123'
-    find('#user_password_confirmation').fill_in with: '123123'
-    find('#new_user input[type=submit]').trigger(:click)
+    find("#user_email").fill_in with: "email@example.com"
+    find("#user_password").fill_in with: "123123"
+    find("#user_password_confirmation").fill_in with: "123123"
+    find("#new_user input[type=submit]").trigger(:click)
 
     ##
     # wind up on the View Plan page, make an edit, and save the plan
-    assert_current_path('/plans')
-    assert page.has_content?('Welcome! You have signed up successfully.')
-    assert page.has_content?('Saved Armenia Plan') # ugh without this form field(s) dont get filled
+    assert_current_path("/plans")
+    assert page.has_content?("Welcome! You have signed up successfully.")
+    assert page.has_content?("Saved Armenia Plan") # ugh without this form field(s) dont get filled
   end
 
-  test 'happy path for Nigeria JEE 1.0 plan by technical areas 5-year' do
+  test "happy path for Nigeria JEE 1.0 plan by technical areas 5-year" do
     visit root_url
-    click_on('Get Started') until current_path == '/get-started'
+    click_on("Get Started") until current_path == "/get-started"
     assert page.has_content?("LET'S GET STARTED")
 
-    select_from_chosen('Nigeria', from: 'get_started_form_country_id')
-    click_on('Next')
-    choose 'Joint External Evaluation (JEE)' #   fails form validation. extra weird because that same flow works in the other test cases.
-    check 'Optional: Plan by technical area(s)'
+    select_from_chosen("Nigeria", from: "get_started_form_country_id")
+    click_on("Next")
+    choose "Joint External Evaluation (JEE)" #   fails form validation. extra weird because that same flow works in the other test cases.
+    check "Optional: Plan by technical area(s)"
     sleep 0.1
-    check 'IHR coordination, communication and advocacy'
-    check 'Surveillance'
+    check "IHR coordination, communication and advocacy"
+    check "Surveillance"
     sleep 0.2
-    choose '5 year plan'
-    click_on('Next')
+    choose "5 year plan"
+    click_on("Next")
 
     ##
     # turn up on the plan goal-setting page
-    assert_current_path('/plan/goals/Nigeria/jee1/5-year?areas=2-9')
-    assert page.has_content?('JEE SCORES')
+    assert_current_path("/plan/goals/Nigeria/jee1/5-year?areas=2-9")
+    assert page.has_content?("JEE SCORES")
     assert page.has_content?(
-             'P.2.1 A functional mechanism is established for the coordination and integration of relevant sectors in the implementation of IHR'
+             "P.2.1 A functional mechanism is established for the coordination and integration of relevant sectors in the implementation of IHR"
            )
     assert page.has_content?(
-             'D.2.1 Indicator- and event-based surveillance systems'
+             "D.2.1 Indicator- and event-based surveillance systems"
            )
-    assert_equal '2', find('#plan_indicators_jee1_ind_p21').value
+    assert_equal "2", find("#plan_indicators_jee1_ind_p21").value
 
     # verify that this 5-year plan has goal set to 4 instead of 3
-    assert_equal '4', find('#plan_indicators_jee1_ind_p21_goal').value
-    find('#new_plan input[type=submit]').trigger(:click)
+    assert_equal "4", find("#plan_indicators_jee1_ind_p21_goal").value
+    find("#new_plan input[type=submit]").trigger(:click)
 
     ##
     # turn up on the View Plan, make an edit, save the plan
     assert_current_path(%r{^\/plans\/\d+$})
-    assert_equal 'Nigeria draft plan', find('#plan_name').value
-    assert_equal 'Actions', find('.action-count-component .label').text
-    assert_equal '130', find('.action-count-component .count').text
+    assert_equal "Nigeria draft plan", find("#plan_name").value
+    assert_equal "Actions", find(".action-count-component .label").text
+    assert_equal "130", find(".action-count-component .count").text
     assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     # verify nudge content for 5-year plan
-    assert_selector('.nudge-container') do
+    assert_selector(".nudge-container") do
       assert page.has_content?(
-               '5 year plans are useful for long-term planning and budgeting but should still be prioritized and realistic'
+               "5 year plans are useful for long-term planning and budgeting but should still be prioritized and realistic"
              )
     end
 
@@ -406,29 +400,29 @@ class AppsTest < ApplicationSystemTestCase
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
     # un-filter to show all
-    find('.clear-filters-component a').click
+    find(".clear-filters-component a").click
     assert_selector("div[data-benchmark-indicator-display-abbrev='2.1']")
     assert_selector("div[data-benchmark-indicator-display-abbrev='9.1']")
 
-    find('#plan_name').fill_in with: 'Saved Nigeria Plan by Areas 789'
-    find('input[type=submit]').trigger(:click)
+    find("#plan_name").fill_in with: "Saved Nigeria Plan by Areas 789"
+    find("input[type=submit]").trigger(:click)
 
     ##
     # wind up on sign-in page and go to create an account
-    assert_current_path('/users/sign_in')
-    click_link('Create an account')
+    assert_current_path("/users/sign_in")
+    click_link("Create an account")
 
     ##
     # wind up on create account page
-    assert_current_path('/users/sign_up')
+    assert_current_path("/users/sign_up")
     sleep 0.1
-    find('#user_email').fill_in with: 'email@example.com'
-    find('#user_password').fill_in with: '123123'
-    find('#user_password_confirmation').fill_in with: '123123'
-    find('#new_user input[type=submit]').trigger(:click)
+    find("#user_email").fill_in with: "email@example.com"
+    find("#user_password").fill_in with: "123123"
+    find("#user_password_confirmation").fill_in with: "123123"
+    find("#new_user input[type=submit]").trigger(:click)
 
-    assert_current_path('/plans')
-    assert page.has_content?('Welcome! You have signed up successfully.')
-    assert page.has_content?('Saved Nigeria Plan by Areas 789') # ugh without this form field(s) dont get filled
+    assert_current_path("/plans")
+    assert page.has_content?("Welcome! You have signed up successfully.")
+    assert page.has_content?("Saved Nigeria Plan by Areas 789") # ugh without this form field(s) dont get filled
   end
 end


### PR DESCRIPTION
Phone size now stacked as per Figma:
<img width="300" src="https://user-images.githubusercontent.com/78/112410725-e8b60680-8cd8-11eb-93c1-647140ce9179.png">

Full width stays the same:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/78/112410787-04b9a800-8cd9-11eb-90c8-6bff34ea4902.png">

Intermediate width now puts filters on top of chart instead of below as before:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/78/112410848-1e5aef80-8cd9-11eb-854f-04e3eb7b1507.png">


Finishes [#177256232].