### PR TITLE
Security Updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.6)
+    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -248,11 +248,11 @@ GEM
     sentry-rails (4.3.2)
       rails (>= 5.0)
       sentry-ruby-core (~> 4.3.0)
-    sentry-ruby (4.3.1)
+    sentry-ruby (4.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.3.1)
-    sentry-ruby-core (4.3.1)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
       concurrent-ruby
       faraday
     sexp_processor (4.15.2)

--- a/package.json
+++ b/package.json
@@ -38,15 +38,6 @@
     "stimulus": "^2.0.0",
     "turbolinks": "^5.2.0"
   },
-  "prettier": {
-    "semi": false,
-    "singleQuote": false,
-    "rubySingleQuote": false
-  },
-  "scripts": {
-    "postinstall": "husky install",
-    "test": "jest"
-  },
   "devDependencies": {
     "@prettier/plugin-ruby": "^1.5.4",
     "@testing-library/react": "^11.2.5",
@@ -62,6 +53,10 @@
     "react-test-renderer": "^16.14.0",
     "redux-mock-store": "^1.5.4",
     "webpack-dev-server": "^3.11.2"
+  },
+  "scripts": {
+    "postinstall": "husky install",
+    "test": "jest"
   },
   "jest": {
     "setupFiles": [
@@ -79,5 +74,10 @@
   "lint-staged": {
     "*.js": "eslint --cache --fix",
     "*.{js,jsx,css,scss,md,haml,rb}": "prettier --write"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": false,
+    "rubySingleQuote": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "webpack-dev-server": "^3.11.2"
   },
   "resolutions": {
-    "is-svg": ">=4.2.2"
+    "is-svg": ">=4.2.2",
+    "serialize-javascript": ">=3.1.0"
   },
   "scripts": {
     "postinstall": "husky install",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "redux-mock-store": "^1.5.4",
     "webpack-dev-server": "^3.11.2"
   },
+  "resolutions": {
+    "is-svg": ">=4.2.2"
+  },
   "scripts": {
     "postinstall": "husky install",
     "test": "jest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,6 +4445,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
 faye-websocket@^0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
@@ -5070,11 +5075,6 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-comment-regex@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
-  integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
-
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -5676,12 +5676,12 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
-is-svg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
-  integrity sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
+is-svg@>=4.2.2, is-svg@^3.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
+  integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
   dependencies:
-    html-comment-regex "^1.1.0"
+    fast-xml-parser "^3.19.0"
 
 is-symbol@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Force Yarn to upgrade some packages to resolve security issues. Theoretically shouldn't break anything?
