### PR TITLE
Migrate to add Ebola if needed

### DIFF
--- a/app/models/concerns/disease_seed.rb
+++ b/app/models/concerns/disease_seed.rb
@@ -3,18 +3,10 @@ module DiseaseSeed
 
   module ClassMethods
     def seed!
-      return if Disease.count == 2 # Influenza, Cholera
-
       warn "Seeding data for Diseases..."
-      unless Disease.find_by_name("influenza").present?
-        Disease.create!(display: "Influenza", name: "influenza")
-      end
-      unless Disease.find_by_name("cholera").present?
-        Disease.create!(display: "Cholera", name: "cholera")
-      end
-      unless Disease.find_by_name("ebola").present?
-        Disease.create!(display: "Ebola", name: "ebola")
-      end
+      Disease.find_or_create_by!(display: "Influenza", name: "influenza")
+      Disease.find_or_create_by!(display: "Cholera", name: "cholera")
+      Disease.find_or_create_by!(display: "Ebola", name: "ebola")
     end
 
     def unseed!

--- a/db/migrate/20210331185421_add_ebola.rb
+++ b/db/migrate/20210331185421_add_ebola.rb
@@ -1,0 +1,5 @@
+class AddEbola < ActiveRecord::Migration[6.1]
+  def change
+    Disease.seed!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_221558) do
+ActiveRecord::Schema.define(version: 2021_03_31_185421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Seeds don't run on every deploy, so we want to make sure that staging
(and eventually prod) will get the new disease records in question.
We'll probably also need to create a migration that adds in Ebola data
when we get to that.