### PR TITLE
fix the arguments to import SPAR in the migration

### DIFF
--- a/db/migrate/20210401231030_update_scores.rb
+++ b/db/migrate/20210401231030_update_scores.rb
@@ -2,8 +2,7 @@ class UpdateScores < ActiveRecord::Migration[6.1]
   include AssessmentSeed::ClassMethods
 
   def change
-    seed_spar "spar_2018",
-              "data/spar/SPAR Data 2018_2019July9.xlsx",
+    seed_spar "data/spar/SPAR Data 2018_2019July9.xlsx",
               "data/spar/SPAR Data 2019_2021Mar29.xlsx",
               update: true
     seed_jee "data/JEE scores Mar 2021.xlsx", update: true


### PR DESCRIPTION
I missed this when I changed the arguments because the migration had
already run once on my local machine, sigh