### PR TITLE
update hamlit to support prettier's haml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "airrecord", "~> 1.0"
 gem "bcrypt", "~> 3.1"
 gem "bootsnap", "~> 1.7", require: false
 gem "devise", "~> 4.7"
+gem "hamlit", "~> 2.15"
 gem "hamlit-rails", "~> 0.2"
 gem "inline_svg", "~> 1.7"
 gem "pg", "~> 1.2"
@@ -46,4 +47,5 @@ group :test do
   gem "mocha", "~> 1.12"
   gem "rails-controller-testing", "~> 1.0"
 end
+
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
-    hamlit (2.11.0)
+    hamlit (2.15.0)
       temple (>= 0.8.2)
       thor
       tilt
@@ -313,6 +313,7 @@ DEPENDENCIES
   cuprite (~> 0.11)
   devise (~> 4.7)
   factory_bot_rails (~> 6.1)
+  hamlit (~> 2.15)
   hamlit-rails (~> 0.2)
   html2haml (~> 2.2)
   inline_svg (~> 1.7)


### PR DESCRIPTION
prettier checks the `haml` version, but doesn't check the `hamlit`
version. we have a haml version new enough, and it seems to be getting
used in development, but in staging/production it seems that we are
using an older version of `hamlit`, that does not support multiline
attributes, and that's why we're getting the errors.