### PR TITLE
count references correctly after filtering

### DIFF
--- a/app/javascript/src/controllers/reference_library_controller.js
+++ b/app/javascript/src/controllers/reference_library_controller.js
@@ -61,7 +61,7 @@ export default class extends Controller {
   }
 
   updateDocumentCountDisplay() {
-    const newCount = $(".document.row:visible", this.element).length
+    const newCount = $(".document.row", this.element).length
     const referenceWord = newCount === 1 ? "reference" : "references"
     const countDisplayText = `<b>${newCount}</b> ${referenceWord}`
     $(this.documentCountTarget).html(countDisplayText)


### PR DESCRIPTION
We were previously counting only visible documents, which meant that hiding and showing documents repeatedly could get the counter into a weird state where it counted before or after hiding or showing had finished. Now that we are replacing the document list entirely on filtering, we can just count all documents and have the right number.