### PR TITLE
Delete old and unassociated plans

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -39,9 +39,15 @@ class Plan < ApplicationRecord
             .first
         }
 
+  scope :purgeable, -> { where("updated_at < ?", 2.weeks.ago).where(user: nil) }
+
   validates :assessment, presence: true
   validates :name, presence: true
   validates :term, inclusion: TERM_TYPES
+
+  def self.purge_old_plans!(dry_run: false)
+    dry_run ? purgeable : purgeable.delete_all
+  end
 
   def is_5_year?
     term.eql?(TERM_TYPES.second)

--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,0 +1,10 @@
+desc "Purge old and abandoned plans"
+task :purge do
+  purgeable_plans = Plan.purgeable
+
+  return if purgeable_plans.empty?
+
+  warn "Purging #{purgeable_plans.count} plans..."
+  Plans.purge_old_plans!
+  warn "Purged #{purgeable_plans.count} plans."
+end

--- a/test/factories/plan_factory.rb
+++ b/test/factories/plan_factory.rb
@@ -1,40 +1,42 @@
 FactoryBot.define do
-  factory :user do
-    role { "Country Planner" }
-    sequence :email do |n|
-      "user-#{n}@example.com"
-    end
-    password { "password" }
-  end
-
   factory :plan do
-    name { "Nigeria Draft Plan" }
-    assessment do
-      Assessment.find_by_country_alpha3_and_assessment_publication_id!("NGA", 1)
-    end
+    name { "#{assessment.country.name} Draft Plan" }
+    assessment
     term { Plan::TERM_TYPES.first }
 
     factory :plan_nigeria_jee1 do
+      name { "Nigeria Draft Plan" }
+      assessment do
+        Assessment.find_by_country_alpha3_and_assessment_publication_id!(
+          "NGA",
+          1
+        )
+      end
+
       after :create do |plan|
         plan.goals =
-          JSON.parse(
-            File.read(
-              File.join(
-                Rails.root,
-                "/test/fixtures/files/plan_for_nigeria_jee1/plan_goals.json",
-              ),
-            ),
-          ).map { |attrs| PlanGoal.new(attrs) }
+          JSON
+            .parse(
+              File.read(
+                File.join(
+                  Rails.root,
+                  "/test/fixtures/files/plan_for_nigeria_jee1/plan_goals.json"
+                )
+              )
+            )
+            .map { |attrs| PlanGoal.new(attrs) }
 
         plan.plan_actions =
-          JSON.parse(
-            File.read(
-              File.join(
-                Rails.root,
-                "/test/fixtures/files/plan_for_nigeria_jee1/plan_actions.json",
-              ),
-            ),
-          ).map { |attrs| PlanAction.new(attrs) }
+          JSON
+            .parse(
+              File.read(
+                File.join(
+                  Rails.root,
+                  "/test/fixtures/files/plan_for_nigeria_jee1/plan_actions.json"
+                )
+              )
+            )
+            .map { |attrs| PlanAction.new(attrs) }
       rescue ActiveRecord::RecordNotSaved => rns
         # try to show the developer some useful feedback for when they forgot to populate seed data
         show_seed_warning rns

--- a/test/factories/plan_factory.rb
+++ b/test/factories/plan_factory.rb
@@ -1,18 +1,12 @@
 FactoryBot.define do
   factory :plan do
-    name { "#{assessment.country.name} Draft Plan" }
-    assessment
+    name { "Nigeria Draft Plan" }
+    assessment do
+      Assessment.find_by_country_alpha3_and_assessment_publication_id!("NGA", 1)
+    end
     term { Plan::TERM_TYPES.first }
 
     factory :plan_nigeria_jee1 do
-      name { "Nigeria Draft Plan" }
-      assessment do
-        Assessment.find_by_country_alpha3_and_assessment_publication_id!(
-          "NGA",
-          1
-        )
-      end
-
       after :create do |plan|
         plan.goals =
           JSON

--- a/test/factories/user_factory.rb
+++ b/test/factories/user_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    role { "Country Planner" }
+    sequence :email do |n|
+      "user-#{n}@example.com"
+    end
+    password { "password" }
+  end
+end

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -855,4 +855,34 @@ describe Plan do
       _(updated_plan.plan_actions.size).must_equal 236
     end
   end
+
+  describe ".purgeable" do
+    describe "with a plan more than 2 weeks old and no user" do
+      it "returns a matching record" do
+        plan = create(:plan_nigeria_jee1, updated_at: 3.weeks.ago)
+        results = Plan.purgeable
+
+        _(results).wont_be_empty
+        _(results.first).must_be_instance_of Plan
+      end
+    end
+
+    describe "with a plan less than 2 weeks old" do
+      it "returns no matching records" do
+        plan = create(:plan, updated_at: 1.weeks.ago)
+        results = Plan.purgeable
+
+        _(results).must_be_empty
+      end
+    end
+
+    describe "with a plan with a user" do
+      it "returns no matching records" do
+        plan = create(:plan, :with_user)
+        results = Plan.purgeable
+
+        _(results).must_be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a purgeable scope on Plan and a rake task to destroy all purgeable plans.