### PR TITLE
remove duplicate cell merges

### DIFF
--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -52,6 +52,11 @@ class Worksheet
         end
       end
     end
+
+    # Remove duplicate merged cells before writing, Excel hates those
+    @workbook.worksheets.each do |w|
+      w.merged_cells.uniq! { |c| [c.ref.row_range, c.ref.col_range] }
+    end
   end
 
   def create_instructions_sheet(worksheet)


### PR DESCRIPTION
for some reason, the existing worksheet generation code creates multiple records for some cells that we want to merge together. my theory is that it's a bug in RubyXL, but I'm not positive. either way, this code cleans up merges right before saving the file to make sure we don't have any duplicate entries. this makes excel much happier with our spreadsheets.