### PR TITLE
Make Microsoft Excel respect the page breaks we are now generating

### DIFF
--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -53,9 +53,12 @@ class Worksheet
       end
     end
 
-    # Remove duplicate merged cells before writing, Excel hates those
     @workbook.worksheets.each do |w|
+      # Remove duplicate merged cells before writing, Excel hates those
       w.merged_cells.uniq! { |c| [c.ref.row_range, c.ref.col_range] }
+
+      # Manually set `manual_break_count`, it seems like it's not generated?
+      w.row_breaks&.manual_break_count = w.row_breaks.select { |b| b.man }.count
     end
   end
 


### PR DESCRIPTION
It seems like setting the count of manual page breaks is the only way to get Excel to honor them... otherwise it just throws them away. LibreOffice doesn't need the count to use them, but who knows. Complicated standards are hard.