### PR TITLE
Resolve Excel error in downloadable worksheets

### DIFF
--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -63,6 +63,7 @@ class Worksheet
   end
 
   def create_instructions_sheet(worksheet)
+    worksheet.sheet_name = "Instructions"
     SpreadsheetCell.new worksheet, 0, 0, text: "Instructions"
     SpreadsheetCell.new worksheet,
                         2,

--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -22,22 +22,23 @@ class Worksheet
     create_instructions_sheet @workbook[0]
     ta_xlsx_worksheets = []
     current_worksheet = nil
-    @benchmark_technical_areas
-      .each_with_index do |benchmark_technical_area, ta_index|
-      benchmark_technical_area.benchmark_indicators
-        .each do |benchmark_indicator|
+    @benchmark_technical_areas.each do |benchmark_technical_area|
+      indicator_actions =
+        benchmark_technical_area.benchmark_indicators
+          .map do |benchmark_indicator|
+          [benchmark_indicator, @plan.actions_for(benchmark_indicator)]
+        end.reject { |i, a| a.empty? }.to_h
+      next if indicator_actions.empty?
+
+      current_worksheet =
+        @workbook.add_worksheet(benchmark_technical_area.full_name)
+      ta_xlsx_worksheets << current_worksheet
+      current_worksheet.row_breaks = RubyXL::BreakList.new
+
+      indicator_actions.each do |benchmark_indicator, plan_actions|
         row_index = 0
         goal_value =
           @plan.goal_value_for(benchmark_indicator: benchmark_indicator)
-        plan_actions = @plan.actions_for(benchmark_indicator)
-        next if plan_actions.empty?
-
-        if ta_xlsx_worksheets[ta_index].blank?
-          current_worksheet =
-            @workbook.add_worksheet(benchmark_technical_area.text)
-          ta_xlsx_worksheets << current_worksheet
-          current_worksheet.row_breaks = RubyXL::BreakList.new
-        end
         plan_actions.each do |plan_action|
           assessment_label = @plan.type_description
           row_index =

--- a/app/lib/worksheet.rb
+++ b/app/lib/worksheet.rb
@@ -55,7 +55,7 @@ class Worksheet
 
     @workbook.worksheets.each do |w|
       # Remove duplicate merged cells before writing, Excel hates those
-      w.merged_cells.uniq! { |c| [c.ref.row_range, c.ref.col_range] }
+      w.merged_cells&.uniq! { |c| [c.ref.row_range, c.ref.col_range] }
 
       # Manually set `manual_break_count`, it seems like it's not generated?
       w.row_breaks&.manual_break_count = w.row_breaks.select { |b| b.man }.count

--- a/app/models/benchmark_technical_area.rb
+++ b/app/models/benchmark_technical_area.rb
@@ -5,6 +5,10 @@ class BenchmarkTechnicalArea < ApplicationRecord
 
   default_scope { order(:sequence) }
 
+  def full_name
+    "#{sequence}. #{text}"
+  end
+
   def as_json(options = {})
     super(options.reverse_merge(only: %i[id text sequence]))
   end

--- a/test/lib/worksheet_test.rb
+++ b/test/lib/worksheet_test.rb
@@ -8,7 +8,8 @@ class WorksheetTest < ActiveSupport::TestCase
     assert_equal 19, workbook.worksheets.size
 
     # verify the first worksheet
-    sheet = workbook[0]
+    sheet = workbook["Instructions"]
+    assert_equal sheet, workbook[0]
     assert_not_nil sheet
     assert_equal "Instructions", sheet[0][0].value
     assert_equal "1. Use these worksheets in your workshop to discuss key items for each action recommended for stepping up.",
@@ -18,7 +19,7 @@ class WorksheetTest < ActiveSupport::TestCase
 
     # verify the IHR Coordination.. worksheet, because its in the middle somewhat
     sheet =
-      workbook["IHR Coordination, Communication and Advocacy and Reporting"]
+      workbook["2. IHR Coordination, Communication and Advocacy and Reporting"]
     assert_not_nil sheet
     assert_equal "Benchmark Objective:", sheet[0][0].value
     assert_equal "To establish a multisectoral IHR coordination mechanism to support the implementation of prevention, detection and response activities",
@@ -35,7 +36,7 @@ class WorksheetTest < ActiveSupport::TestCase
     assert_equal "Regularly test the mechanism for multisectoral collaboration and communication through actual experience and/or scenarios for high risk, deliberate or mass gathering events.",
                  sheet[Worksheet::SECTION_ROW_OFFSET * 3 + 7][0].value
 
-    # verify the first worksheet
+    # verify the last worksheet
     sheet = workbook[workbook.worksheets.size - 1]
     assert_not_nil sheet
     assert_equal "Benchmark Objective:", sheet[0][0].value


### PR DESCRIPTION
we cannot, it turns out, use the index to check whether a worksheet
exists yet, because we don't use the index to insert the worksheet.
if you just plop new sheets on to the end, but skip sheets if there
are no actions, you might not have sheets that line up exactly with
indexes. and then excel will freak out, because you have added pages
to sheets that you never created. so we will stop doing that.