### PR TITLE
Retry on Ferrum:PendingConnectionsError in Capybara tests

### DIFF
--- a/test/capybara_helper.rb
+++ b/test/capybara_helper.rb
@@ -7,4 +7,15 @@ module CapybaraHelper
     find("##{field[:id]}_chosen").click
     find("##{field[:id]}_chosen ul.chosen-results li", text: item_text).click
   end
+
+  def retry_on_pending_connection
+    retries = 0
+
+    begin
+      yield
+    rescue Ferrum::PendingConnectionsError
+      retries += 1
+      retry unless retries > 3
+    end
+  end
 end

--- a/test/capybara_helper.rb
+++ b/test/capybara_helper.rb
@@ -8,6 +8,8 @@ module CapybaraHelper
     find("##{field[:id]}_chosen ul.chosen-results li", text: item_text).click
   end
 
+  # Someday Ferrum will have a better way to handle that pending connection issue.
+  # For now, this prevents system tests from flaking on that particular error.
   def retry_on_pending_connection
     retries = 0
 
@@ -15,7 +17,10 @@ module CapybaraHelper
       yield
     rescue Ferrum::PendingConnectionsError
       retries += 1
-      retry unless retries > 3
+      unless retries > 3
+        puts "Ferrum failed with PendingConnectionsError, retrying. (Retry ##{retries})"
+        retry
+      end
     end
   end
 end

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -286,8 +286,11 @@ class AppsTest < ApplicationSystemTestCase
     assert page.has_content?("Saved Nigeria Plan 789")
     sleep 0.2
     click_on("Saved Nigeria Plan 789")
-    sleep 1
-    assert page.find("h3", text: "National Legislation, Policy and Financing")
+
+    retry_on_pending_connection do
+      assert page.find("h3", text: "National Legislation, Policy and Financing")
+    end
+
     click_on("email@example.com")
     click_on("My Plans")
     assert page.has_content?("Saved Nigeria Plan 789")

--- a/test/system/apps_test.rb
+++ b/test/system/apps_test.rb
@@ -286,6 +286,7 @@ class AppsTest < ApplicationSystemTestCase
     assert page.has_content?("Saved Nigeria Plan 789")
     sleep 0.2
     click_on("Saved Nigeria Plan 789")
+    sleep 1
     assert page.find("h3", text: "National Legislation, Policy and Financing")
     click_on("email@example.com")
     click_on("My Plans")


### PR DESCRIPTION
Tests are failing intermittently on that `Ferrum::PendingConnectionsError`. This fixes it by retrying automatically.