### PR TITLE
Button says "invalid data" when you submit scores page #178452962

### DIFF
--- a/app/javascript/src/controllers/get_started_controller.js
+++ b/app/javascript/src/controllers/get_started_controller.js
@@ -32,7 +32,6 @@ export default class extends Controller {
   }
 
   selectAssessment(e) {
-    console.log(e)
     $(this.planByTechnicalAreasContainerTargets)
       .hide()
       .filter('[data-assessment-named-id="' + e.target.value + '"]')

--- a/app/views/plans/goals.html.erb
+++ b/app/views/plans/goals.html.erb
@@ -79,7 +79,7 @@
 
     <div class="row">
       <div class="col d-flex justify-content-end">
-        <%= form.submit "Next", class: "btn btn-primary goals-next-button", "data-score-target": "submitButton", "data-disable-with": "Invalid data" %>
+        <%= form.submit "Next", class: "btn btn-primary goals-next-button", "data-score-target": "submitButton", "data-disable-with": "Loading…" %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
- change the "data-disable-with" property which is displayed when the form is being submitted and the submit button disabled to "Loading…" instead of "Invalid data". There is already a code patht to set the button to read "Invalid data" as part of form validation, and its the wrong message for a successful submission.
- remove console.log statement left behind in a prior commit from the selectAssessment method