### PR TITLE
Bug: task to purge plans fails with an error #179043904

### DIFF
--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,10 +1,9 @@
 desc "Purge old and abandoned plans"
-task :purge do
+task purge: :environment do
   purgeable_plans = Plan.purgeable
-
-  return if purgeable_plans.empty?
-
-  warn "Purging #{purgeable_plans.count} plans..."
-  Plans.purge_old_plans!
-  warn "Purged #{purgeable_plans.count} plans."
+  if purgeable_plans.any?
+    warn "Purging #{purgeable_plans.count} plans..."
+    Plans.purge_old_plans!
+    warn "Purged #{purgeable_plans.count} plans."
+  end
 end


### PR DESCRIPTION
- add :environment as a dependency task so that the Rails env is loaded, was causing errors in Heroku: NameError: uninitialized constant Plan
- rearrange the conditional because when I ran it locally i got LocalJumpError: unexpected return so prob cannot use return in a rake task outside of a method