### PR TITLE
task to purge plans fails with an error #179043904

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -11,6 +11,7 @@ class Plan < ApplicationRecord
   # TODO: update this implementation once the assessments page is modernized
   ASSESSMENT_TYPE_NAMED_IDS = %w[jee1 spar_2018 jee2].freeze
   TERM_TYPES = [100, 500] # 100 is 1-year, 500 is 5-year
+  PURGEABLE_WEEKS = 2.freeze
   include PlanBuilder
 
   belongs_to :assessment
@@ -38,7 +39,10 @@ class Plan < ApplicationRecord
       .first
   end
 
-  scope :purgeable, -> { where("updated_at < ?", 2.weeks.ago).where(user: nil) }
+  scope :purgeable,
+        -> {
+          where("updated_at < ?", PURGEABLE_WEEKS.weeks.ago).where(user: nil)
+        }
 
   validates :assessment, presence: true
   validates :name, presence: true

--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,9 +1,9 @@
-desc "Purge old and abandoned plans"
+desc "Purge plans that are unassociated to a user and more than #{Plan::PURGEABLE_WEEKS} weeks old"
 task purge: :environment do
-  purgeable_plans = Plan.purgeable
-  if purgeable_plans.any?
-    warn "Purging #{purgeable_plans.count} plans..."
-    Plans.purge_old_plans!
-    warn "Purged #{purgeable_plans.count} plans."
+  purgeable_plan_count = Plan.purgeable.count
+  if purgeable_plan_count > 0
+    warn "Purging #{purgeable_plan_count} plans..."
+    Plan.purge_old_plans!
+    warn "Purged #{purgeable_plan_count} plans."
   end
 end


### PR DESCRIPTION
- fix 'Plans' to 'Plan' which was causing 'NameError: uninitialized constant Plans' when run in Heroku envs
- change variable to purgeable_plan_count to simplify the rake task
- add constant PURGEABLE_WEEKS to use in human-readable task description
