### PR TITLE
task to purge plans fails with an error #179043904

### DIFF
--- a/lib/tasks/purge.rake
+++ b/lib/tasks/purge.rake
@@ -1,4 +1,4 @@
-desc "Purge plans that are unassociated to a user and more than #{Plan::PURGEABLE_WEEKS} weeks old"
+desc "Purge plans that are unassociated to a user and more than Plan::PURGEABLE_WEEKS weeks old"
 task purge: :environment do
   purgeable_plan_count = Plan.purgeable.count
   if purgeable_plan_count > 0


### PR DESCRIPTION
- just show the text of Plan::PURGEABLE_WEEKS since the Plan class is not available in the description context
